### PR TITLE
Update to Rust nightly 2015-01-02

### DIFF
--- a/src/errno.rs
+++ b/src/errno.rs
@@ -8,7 +8,7 @@ pub use self::consts::Errno::*;
 
 pub type SysResult<T> = Result<T, SysError>;
 
-#[deriving(Clone, PartialEq, Copy)]
+#[derive(Clone, PartialEq, Copy)]
 pub struct SysError {
     pub kind: Errno,
 }
@@ -420,7 +420,7 @@ pub fn from_ffi(res: c_int) -> SysResult<()> {
 
 #[cfg(target_os = "linux")]
 mod consts {
-    #[deriving(Show, Clone, PartialEq, FromPrimitive, Copy)]
+    #[derive(Show, Clone, PartialEq, FromPrimitive, Copy)]
     pub enum Errno {
         UnknownErrno    = 0,
         EPERM           = 1,
@@ -562,7 +562,7 @@ mod consts {
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 mod consts {
-    #[deriving(Copy, Show, Clone, PartialEq, FromPrimitive)]
+    #[derive(Copy, Show, Clone, PartialEq, FromPrimitive)]
     pub enum Errno {
         UnknownErrno    = 0,
         EPERM           = 1,

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::c_str::ToCStr;
 use std::io::FilePermission;
 use libc::{c_int, mode_t};
 use errno::{SysResult, SysError};
@@ -18,7 +19,7 @@ mod ffi {
         use libc::{c_int, c_short, off_t, pid_t};
 
         #[repr(C)]
-        #[deriving(Copy)]
+        #[derive(Copy)]
         pub struct flock {
             pub l_type: c_short,
             pub l_whence: c_short,
@@ -46,7 +47,7 @@ mod ffi {
         use libc::{c_int, c_short, off_t, pid_t};
 
         #[repr(C)]
-        #[deriving(Copy)]
+        #[derive(Copy)]
         pub struct flock {
             pub l_start: off_t,
             pub l_len: off_t,

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -1,5 +1,6 @@
 use std::ptr;
 use std::path::Path;
+use std::c_str::ToCStr;
 use libc::{c_ulong, c_int, c_void};
 use errno::{SysResult, from_ffi};
 

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -69,7 +69,7 @@ pub type CpuMask = c_ulong;
 
 // Structure representing the CPU set to apply
 #[repr(C)]
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct CpuSet {
     cpu_mask: [CpuMask; cpuset_attribs::CPU_SETSIZE/cpuset_attribs::CPU_MASK_BITS]
 }

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -69,7 +69,7 @@ impl fmt::Show for EpollEventKind {
     }
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 #[repr(C)]
 pub enum EpollOp {
     EpollCtlAdd = 1,
@@ -77,7 +77,7 @@ pub enum EpollOp {
     EpollCtlMod = 3
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 #[repr(C, packed)]
 pub struct EpollEvent {
     pub events: EpollEventKind,

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -12,7 +12,7 @@ mod ffi {
     pub use libc::{c_int, c_void, uintptr_t, intptr_t, timespec};
     use super::{EventFilter, EventFlag, FilterFlag};
 
-    #[deriving(Copy)]
+    #[derive(Copy)]
     #[repr(C)]
     pub struct kevent {
         pub ident: uintptr_t,       // 8
@@ -39,7 +39,7 @@ mod ffi {
 }
 
 #[repr(i16)]
-#[deriving(Copy, Show, PartialEq)]
+#[derive(Copy, Show, PartialEq)]
 pub enum EventFilter {
     EVFILT_READ = -1,
     EVFILT_WRITE = -2,

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -1,5 +1,6 @@
 use errno::{SysResult, SysError};
 use std::io::FilePermission;
+use std::c_str::ToCStr;
 use fcntl::{Fd, OFlag};
 use libc::{c_void, size_t, off_t, mode_t};
 

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -95,7 +95,7 @@ pub mod signal {
     // actually a giant union. Currently we're only interested in these fields,
     // however.
     #[repr(C)]
-    #[deriving(Copy)]
+    #[derive(Copy)]
     pub struct siginfo {
         si_signo: libc::c_int,
         si_errno: libc::c_int,
@@ -116,14 +116,14 @@ pub mod signal {
 
     #[repr(C)]
     #[cfg(target_word_size = "32")]
-    #[deriving(Copy)]
+    #[derive(Copy)]
     pub struct sigset_t {
         __val: [libc::c_ulong; 32],
     }
 
     #[repr(C)]
     #[cfg(target_word_size = "64")]
-    #[deriving(Copy)]
+    #[derive(Copy)]
     pub struct sigset_t {
         __val: [libc::c_ulong; 16],
     }
@@ -248,7 +248,7 @@ pub mod signal {
     // This structure has more fields, but we're not all that interested in
     // them.
     #[repr(C)]
-    #[deriving(Copy)]
+    #[derive(Copy)]
     pub struct siginfo {
         pub si_signo: libc::c_int,
         pub si_errno: libc::c_int,
@@ -296,7 +296,7 @@ mod ffi {
     }
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct SigSet {
     sigset: sigset_t
 }

--- a/src/sys/socket.rs
+++ b/src/sys/socket.rs
@@ -31,7 +31,7 @@ bitflags!(
     }
 );
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub enum SockAddr {
     SockIpV4(sockaddr_in),
     SockIpV6(sockaddr_in6),
@@ -444,7 +444,7 @@ pub fn sendto(sockfd: Fd, buf: &[u8], addr: &SockAddr, flags: SockMessageFlags) 
 }
 
 #[repr(C)]
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct linger {
     pub l_onoff: c_int,
     pub l_linger: c_int

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::io::FilePermission;
 use std::mem;
 use std::path::Path;
+use std::c_str::ToCStr;
 use libc::mode_t;
 use errno::{SysResult, SysError, from_ffi};
 use fcntl::Fd;

--- a/src/sys/utsname.rs
+++ b/src/sys/utsname.rs
@@ -15,7 +15,7 @@ mod ffi {
 const UTSNAME_LEN: uint = 65;
 
 #[repr(C)]
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct UtsName {
     sysname: [c_char; UTSNAME_LEN],
     nodename: [c_char; UTSNAME_LEN],

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -15,7 +15,7 @@ bitflags!(
     }
 );
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub enum WaitStatus {
     Exited(pid_t),
     StillAlive

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -53,7 +53,7 @@ mod ffi {
     }
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub enum Fork {
     Parent(pid_t),
     Child
@@ -102,9 +102,9 @@ pub fn fork() -> SysResult<Fork> {
 type IovecR = Iovec<ToRead>;
 type IovecW = Iovec<ToWrite>;
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct ToRead;
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct ToWrite;
 
 #[repr(C)]
@@ -411,6 +411,7 @@ pub fn ftruncate(fd: Fd, len: off_t) -> SysResult<()> {
 #[cfg(target_os = "linux")]
 mod linux {
     use std::path::Path;
+    use std::c_str::ToCStr;
     use syscall::{syscall, SYSPIVOTROOT};
     use errno::{SysResult, SysError};
 

--- a/tests/unistd.rs
+++ b/tests/unistd.rs
@@ -5,6 +5,7 @@ mod test {
     use nix::unistd::{writev, readv, Iovec, pipe, close, read, write};
     use std::rand::{thread_rng, Rng};
     use std::cmp::min;
+    use std::iter;
 
     #[test]
     fn test_writev() {
@@ -28,7 +29,8 @@ mod test {
         assert!(pipe_res.is_ok());
         let (reader, writer) = pipe_res.ok().unwrap();
         // FileDesc will close its filedesc (reader).
-        let mut read_buf = Vec::from_elem(128 * 16, 0u8);
+        let mut read_buf: Vec<u8> = iter::repeat(0).take(128 * 16).collect();
+
         // Blocking io, should write all data.
         let write_res = writev(writer, iovecs.as_slice());
         // Successful write
@@ -59,7 +61,7 @@ mod test {
         while allocated < to_write.len() {
             let left = to_write.len() - allocated;
             let vec_len = if left < 64 { left } else { thread_rng().gen_range(64, min(256, left)) };
-            let v = Vec::from_elem(vec_len, 0u8);
+            let v: Vec<u8> = iter::repeat(0).take(vec_len).collect();
             storage.push(v);
             allocated += vec_len;
         }


### PR DESCRIPTION
* Use `#[derive]` instead of `#[deriving]`
* Load `std::c_str::ToCStr` to be able to use `to_c_str`
* `iter::repeat(0).take(..).collect()` instead of `Vec::from_elem(0, ..)`

Tested with `rustc 0.13.0-nightly (c89417130 2015-01-02 21:56:13 +0000)`

There are some warnings about `deriving`, but it seems that they are out of this repository:

```
<std macros>:5:11: 5:71 warning: `deriving` is deprecated; use `derive`
<std macros>:5         #[deriving(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
```