### PR TITLE
replaced deriving with derive and added use std::c_str::ToCStr where nec...

### DIFF
--- a/src/errno.rs
+++ b/src/errno.rs
@@ -8,7 +8,7 @@ pub use self::consts::Errno::*;
 
 pub type SysResult<T> = Result<T, SysError>;
 
-#[deriving(Clone, PartialEq, Copy)]
+#[derive(Clone, PartialEq, Copy)]
 pub struct SysError {
     pub kind: Errno,
 }
@@ -420,7 +420,7 @@ pub fn from_ffi(res: c_int) -> SysResult<()> {
 
 #[cfg(target_os = "linux")]
 mod consts {
-    #[deriving(Show, Clone, PartialEq, FromPrimitive, Copy)]
+    #[derive(Show, Clone, PartialEq, FromPrimitive, Copy)]
     pub enum Errno {
         UnknownErrno    = 0,
         EPERM           = 1,
@@ -562,7 +562,7 @@ mod consts {
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 mod consts {
-    #[deriving(Copy, Show, Clone, PartialEq, FromPrimitive)]
+    #[derive(Copy, Show, Clone, PartialEq, FromPrimitive)]
     pub enum Errno {
         UnknownErrno    = 0,
         EPERM           = 1,

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::c_str::ToCStr;
 use std::io::FilePermission;
 use libc::{c_int, mode_t};
 use errno::{SysResult, SysError};
@@ -18,7 +19,7 @@ mod ffi {
         use libc::{c_int, c_short, off_t, pid_t};
 
         #[repr(C)]
-        #[deriving(Copy)]
+        #[derive(Copy)]
         pub struct flock {
             pub l_type: c_short,
             pub l_whence: c_short,
@@ -46,7 +47,7 @@ mod ffi {
         use libc::{c_int, c_short, off_t, pid_t};
 
         #[repr(C)]
-        #[deriving(Copy)]
+        #[derive(Copy)]
         pub struct flock {
             pub l_start: off_t,
             pub l_len: off_t,

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -1,5 +1,6 @@
 use std::ptr;
 use std::path::Path;
+use std::c_str::ToCStr;
 use libc::{c_ulong, c_int, c_void};
 use errno::{SysResult, from_ffi};
 

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -69,7 +69,7 @@ pub type CpuMask = c_ulong;
 
 // Structure representing the CPU set to apply
 #[repr(C)]
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct CpuSet {
     cpu_mask: [CpuMask; cpuset_attribs::CPU_SETSIZE/cpuset_attribs::CPU_MASK_BITS]
 }

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -69,7 +69,7 @@ impl fmt::Show for EpollEventKind {
     }
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 #[repr(C)]
 pub enum EpollOp {
     EpollCtlAdd = 1,
@@ -77,7 +77,7 @@ pub enum EpollOp {
     EpollCtlMod = 3
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 #[repr(C, packed)]
 pub struct EpollEvent {
     pub events: EpollEventKind,

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -12,7 +12,7 @@ mod ffi {
     pub use libc::{c_int, c_void, uintptr_t, intptr_t, timespec};
     use super::{EventFilter, EventFlag, FilterFlag};
 
-    #[deriving(Copy)]
+    #[derive(Copy)]
     #[repr(C)]
     pub struct kevent {
         pub ident: uintptr_t,       // 8
@@ -39,7 +39,7 @@ mod ffi {
 }
 
 #[repr(i16)]
-#[deriving(Copy, Show, PartialEq)]
+#[derive(Copy, Show, PartialEq)]
 pub enum EventFilter {
     EVFILT_READ = -1,
     EVFILT_WRITE = -2,

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -1,5 +1,6 @@
 use errno::{SysResult, SysError};
 use std::io::FilePermission;
+use std::c_str::ToCStr;
 use fcntl::{Fd, OFlag};
 use libc::{c_void, size_t, off_t, mode_t};
 
@@ -86,9 +87,9 @@ mod consts {
     pub const PROT_WRITE: MmapProt          = 0x2;
     pub const PROT_EXEC: MmapProt           = 0x4;
     pub const PROT_NONE: MmapProt           = 0x0;
-    
+
     pub type MmapAdvise = c_int;
-    
+
     pub const MADV_NORMAL     : MmapAdvise      = 0; /* No further special treatment.  */
     pub const MADV_RANDOM     : MmapAdvise      = 1; /* Expect random page references.  */
     pub const MADV_SEQUENTIAL : MmapAdvise      = 2; /* Expect sequential page references.  */
@@ -98,7 +99,7 @@ mod consts {
     pub const MADV_ZERO_WIRED_PAGES: MmapAdvise = 6; /* zero the wired pages that have not been unwired before the entry is deleted */
     pub const MADV_FREE_REUSABLE : MmapAdvise   = 7; /* pages can be reused (by anyone) */
     pub const MADV_FREE_REUSE : MmapAdvise      = 8; /* caller wants to reuse those pages */
-    pub const MADV_CAN_REUSE : MmapAdvise       = 9; 
+    pub const MADV_CAN_REUSE : MmapAdvise       = 9;
 
     pub type MmapSync = c_int;
 

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -95,7 +95,7 @@ pub mod signal {
     // actually a giant union. Currently we're only interested in these fields,
     // however.
     #[repr(C)]
-    #[deriving(Copy)]
+    #[derive(Copy)]
     pub struct siginfo {
         si_signo: libc::c_int,
         si_errno: libc::c_int,
@@ -116,14 +116,14 @@ pub mod signal {
 
     #[repr(C)]
     #[cfg(target_word_size = "32")]
-    #[deriving(Copy)]
+    #[derive(Copy)]
     pub struct sigset_t {
         __val: [libc::c_ulong; 32],
     }
 
     #[repr(C)]
     #[cfg(target_word_size = "64")]
-    #[deriving(Copy)]
+    #[derive(Copy)]
     pub struct sigset_t {
         __val: [libc::c_ulong; 16],
     }
@@ -248,7 +248,7 @@ pub mod signal {
     // This structure has more fields, but we're not all that interested in
     // them.
     #[repr(C)]
-    #[deriving(Copy)]
+    #[derive(Copy)]
     pub struct siginfo {
         pub si_signo: libc::c_int,
         pub si_errno: libc::c_int,
@@ -296,7 +296,7 @@ mod ffi {
     }
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct SigSet {
     sigset: sigset_t
 }

--- a/src/sys/socket.rs
+++ b/src/sys/socket.rs
@@ -31,7 +31,7 @@ bitflags!(
     }
 );
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub enum SockAddr {
     SockIpV4(sockaddr_in),
     SockIpV6(sockaddr_in6),
@@ -444,7 +444,7 @@ pub fn sendto(sockfd: Fd, buf: &[u8], addr: &SockAddr, flags: SockMessageFlags) 
 }
 
 #[repr(C)]
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct linger {
     pub l_onoff: c_int,
     pub l_linger: c_int

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::io::FilePermission;
 use std::mem;
 use std::path::Path;
+use std::c_str::ToCStr;
 use libc::mode_t;
 use errno::{SysResult, SysError, from_ffi};
 use fcntl::Fd;

--- a/src/sys/utsname.rs
+++ b/src/sys/utsname.rs
@@ -15,7 +15,7 @@ mod ffi {
 const UTSNAME_LEN: uint = 65;
 
 #[repr(C)]
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct UtsName {
     sysname: [c_char; UTSNAME_LEN],
     nodename: [c_char; UTSNAME_LEN],

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -15,7 +15,7 @@ bitflags!(
     }
 );
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub enum WaitStatus {
     Exited(pid_t),
     StillAlive

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -53,7 +53,7 @@ mod ffi {
     }
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub enum Fork {
     Parent(pid_t),
     Child
@@ -102,9 +102,9 @@ pub fn fork() -> SysResult<Fork> {
 type IovecR = Iovec<ToRead>;
 type IovecW = Iovec<ToWrite>;
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct ToRead;
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct ToWrite;
 
 #[repr(C)]
@@ -411,6 +411,7 @@ pub fn ftruncate(fd: Fd, len: off_t) -> SysResult<()> {
 #[cfg(target_os = "linux")]
 mod linux {
     use std::path::Path;
+    use std::c_str::ToCStr;
     use syscall::{syscall, SYSPIVOTROOT};
     use errno::{SysResult, SysError};
 


### PR DESCRIPTION
replaced deriving with derive and added use std::c_str::ToCStr where necessary. now compiles again against latest Rust version.
