### PR TITLE
Fix breakage caused by the removal of unboxed closures

### DIFF
--- a/src/sched.rs
+++ b/src/sched.rs
@@ -62,7 +62,7 @@ mod cpuset_attribs {
     }
 }
 
-pub type CloneCb<'a> = Box<FnMut() -> int + a>;
+pub type CloneCb<'a> = Box<FnMut() -> int + 'a>;
 
 // A single CPU mask word
 pub type CpuMask = c_ulong;

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -62,7 +62,7 @@ mod cpuset_attribs {
     }
 }
 
-pub type CloneCb<'a> = ||:'a -> int;
+pub type CloneCb<'a> = Box<FnMut() -> int + a>;
 
 // A single CPU mask word
 pub type CpuMask = c_ulong;


### PR DESCRIPTION
Unboxed closures have been removed from the language, so this change is needed to compile with the current rust nightly.