### PR TITLE
ToCStr removal fallout

### DIFF
--- a/src/errno.rs
+++ b/src/errno.rs
@@ -404,7 +404,7 @@ impl SysError {
 
 impl fmt::Show for SysError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{} - {}", self.kind, self.desc())
+        write!(fmt, "{:?} - {:?}", self.kind, self.desc())
     }
 }
 

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -1,8 +1,8 @@
-use std::c_str::ToCStr;
 use std::path::Path;
 use std::io::FilePermission;
 use libc::{c_int, mode_t};
 use errno::{SysResult, SysError};
+use utils::ToCStr;
 
 pub use self::consts::*;
 pub use self::ffi::flock;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![crate_name = "nix"]
 
-#![feature(globs)]
 #![feature(linkage)]
 #![allow(non_camel_case_types)]
 
@@ -36,3 +35,5 @@ pub mod syscall;
 
 #[cfg(unix)]
 pub mod unistd;
+
+mod utils;

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -1,8 +1,8 @@
 use errno::{SysResult, SysError};
-use std::c_str::ToCStr;
 use std::io::FilePermission;
 use fcntl::{Fd, OFlag};
 use libc::{c_void, size_t, off_t, mode_t};
+use utils::ToCStr;
 
 pub use self::consts::*;
 

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -1,7 +1,6 @@
 pub use libc::dev_t;
 pub use libc::stat as FileStat;
 
-use std::c_str::ToCStr;
 use std::fmt;
 use std::io::FilePermission;
 use std::mem;
@@ -9,6 +8,7 @@ use std::path::Path;
 use libc::mode_t;
 use errno::{SysResult, SysError, from_ffi};
 use fcntl::Fd;
+use utils::ToCStr;
 
 mod ffi {
     use libc::{c_char, c_int, mode_t, dev_t};

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1,11 +1,12 @@
+use std::ffi::CString;
 use std::{mem, ptr};
-use std::c_str::{CString, ToCStr};
 use libc::{c_char, c_void, c_int, size_t, pid_t, off_t};
 use fcntl::{fcntl, Fd, OFlag, O_NONBLOCK, O_CLOEXEC, FD_CLOEXEC};
 use fcntl::FcntlArg::{F_SETFD, F_SETFL};
 
 use errno::{SysResult, SysError, from_ffi};
 use core::raw::Slice as RawSlice;
+use utils::ToCStr;
 
 #[cfg(target_os = "linux")]
 pub use self::linux::*;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,18 @@
+use std::ffi::CString;
+use std::path::Path;
+
+pub trait ToCStr {
+    fn to_c_str(&self) -> CString;
+}
+
+impl ToCStr for Path {
+    fn to_c_str(&self) -> CString {
+        CString::from_slice(self.as_vec())
+    }
+}
+
+impl ToCStr for String {
+    fn to_c_str(&self) -> CString {
+        CString::from_slice(self.as_bytes())
+    }
+}


### PR DESCRIPTION
- ToCStr removal
- split of `Show` and `String` traits 
- `globs` feature is enabled by default