### PR TITLE
more cstr-fallout

### DIFF
--- a/src/errno.rs
+++ b/src/errno.rs
@@ -404,7 +404,7 @@ impl SysError {
 
 impl fmt::Show for SysError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{} - {}", self.kind, self.desc())
+        write!(fmt, "{:?} - {:?}", self.kind, self.desc())
     }
 }
 

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -1,8 +1,8 @@
-use std::c_str::ToCStr;
 use std::path::Path;
 use std::io::FilePermission;
 use libc::{c_int, mode_t};
 use errno::{SysResult, SysError};
+use utils::ToCStr;
 
 pub use self::consts::*;
 pub use self::ffi::flock;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![crate_name = "nix"]
 
-#![feature(globs)]
 #![feature(linkage)]
 #![allow(non_camel_case_types)]
 
@@ -36,3 +35,5 @@ pub mod syscall;
 
 #[cfg(unix)]
 pub mod unistd;
+
+mod utils;

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -1,8 +1,8 @@
-use std::c_str::ToCStr;
 use std::ptr;
 use std::path::Path;
 use libc::{c_ulong, c_int, c_void};
 use errno::{SysResult, from_ffi};
+use utils::ToCStr;
 
 bitflags!(
     flags MsFlags: c_ulong {

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -1,8 +1,8 @@
 use errno::{SysResult, SysError};
-use std::c_str::ToCStr;
 use std::io::FilePermission;
 use fcntl::{Fd, OFlag};
 use libc::{c_void, size_t, off_t, mode_t};
+use utils::ToCStr;
 
 pub use self::consts::*;
 

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -1,7 +1,6 @@
 pub use libc::dev_t;
 pub use libc::stat as FileStat;
 
-use std::c_str::ToCStr;
 use std::fmt;
 use std::io::FilePermission;
 use std::mem;
@@ -9,6 +8,7 @@ use std::path::Path;
 use libc::mode_t;
 use errno::{SysResult, SysError, from_ffi};
 use fcntl::Fd;
+use utils::ToCStr;
 
 mod ffi {
     use libc::{c_char, c_int, mode_t, dev_t};

--- a/src/sys/utsname.rs
+++ b/src/sys/utsname.rs
@@ -1,6 +1,7 @@
 use std::mem;
-use std::c_str::CString;
 use libc::{c_char};
+use std::ffi::{c_str_to_bytes_with_nul};
+use std::str::from_utf8_unchecked; 
 
 mod ffi {
     use libc::c_int;
@@ -29,23 +30,23 @@ pub struct UtsName {
 
 impl UtsName {
     pub fn sysname<'a>(&'a self) -> &'a str {
-        to_str(&self.sysname as *const c_char)
+        to_str(&(&self.sysname as *const c_char ) as *const *const c_char)
     }
 
     pub fn nodename<'a>(&'a self) -> &'a str {
-        to_str(&self.nodename as *const c_char)
+        to_str(&(&self.nodename as *const c_char ) as *const *const c_char)
     }
 
     pub fn release<'a>(&'a self) -> &'a str {
-        to_str(&self.release as *const c_char)
+        to_str(&(&self.release as *const c_char ) as *const *const c_char)
     }
 
     pub fn version<'a>(&'a self) -> &'a str {
-        to_str(&self.version as *const c_char)
+        to_str(&(&self.version as *const c_char ) as *const *const c_char)
     }
 
     pub fn machine<'a>(&'a self) -> &'a str {
-        to_str(&self.machine as *const c_char)
+        to_str(&(&self.machine as *const c_char ) as *const *const c_char)
     }
 }
 
@@ -58,9 +59,9 @@ pub fn uname() -> UtsName {
 }
 
 #[inline]
-fn to_str<'a>(s: *const c_char) -> &'a str {
+fn to_str<'a>(s: *const *const c_char) -> &'a str {
     unsafe {
-        let res = CString::new(s, false);
-        mem::transmute(res.as_str().expect("[BUG] uname field not UTF-8"))
+        let res = c_str_to_bytes_with_nul(mem::transmute(s));
+        from_utf8_unchecked(res)
     }
 }

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1,4 +1,3 @@
-use std::ffi::CString;
 use std::{mem, ptr};
 use libc::{c_char, c_void, c_int, size_t, pid_t, off_t};
 use fcntl::{fcntl, Fd, OFlag, O_NONBLOCK, O_CLOEXEC, FD_CLOEXEC};
@@ -7,6 +6,7 @@ use fcntl::FcntlArg::{F_SETFD, F_SETFL};
 use errno::{SysResult, SysError, from_ffi};
 use core::raw::Slice as RawSlice;
 use utils::ToCStr;
+use std::ffi::CString; 
 
 #[cfg(target_os = "linux")]
 pub use self::linux::*;
@@ -411,10 +411,10 @@ pub fn ftruncate(fd: Fd, len: off_t) -> SysResult<()> {
 
 #[cfg(target_os = "linux")]
 mod linux {
-    use std::c_str::ToCStr;
     use std::path::Path;
     use syscall::{syscall, SYSPIVOTROOT};
     use errno::{SysResult, SysError};
+    use utils::ToCStr;
 
     pub fn pivot_root(new_root: &Path, put_old: &Path) -> SysResult<()> {
         let new_root = new_root.to_c_str();

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1,11 +1,12 @@
+use std::ffi::CString;
 use std::{mem, ptr};
-use std::c_str::{CString, ToCStr};
 use libc::{c_char, c_void, c_int, size_t, pid_t, off_t};
 use fcntl::{fcntl, Fd, OFlag, O_NONBLOCK, O_CLOEXEC, FD_CLOEXEC};
 use fcntl::FcntlArg::{F_SETFD, F_SETFL};
 
 use errno::{SysResult, SysError, from_ffi};
 use core::raw::Slice as RawSlice;
+use utils::ToCStr;
 
 #[cfg(target_os = "linux")]
 pub use self::linux::*;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,6 +11,13 @@ impl ToCStr for Path {
     }
 }
 
+impl<'a> ToCStr for &'a str {
+    fn to_c_str(&self) -> CString {
+        CString::from_slice(self.as_bytes())
+    }
+}
+
+
 impl ToCStr for String {
     fn to_c_str(&self) -> CString {
         CString::from_slice(self.as_bytes())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,18 @@
+use std::ffi::CString;
+use std::path::Path;
+
+pub trait ToCStr {
+    fn to_c_str(&self) -> CString;
+}
+
+impl ToCStr for Path {
+    fn to_c_str(&self) -> CString {
+        CString::from_slice(self.as_vec())
+    }
+}
+
+impl ToCStr for String {
+    fn to_c_str(&self) -> CString {
+        CString::from_slice(self.as_bytes())
+    }
+}


### PR DESCRIPTION
I checked out the cstr-fallout [branch](https://github.com/carllerche/nix-rust/pull/44)  by @vhbit but I found a few more things needed to be updated, like src/mount,   also src/sys/utsname.rs's to_str needed to be reworked because those functions don't exist anymore. 

