### PR TITLE
Add a new dependency to bitflags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ authors     = ["Carl Lerche <me@carllerche.com>"]
 homepage    = "https://github.com/carllerche/nix-rust"
 license     = "MIT"
 exclude     = [".gitignore", ".travis.yml", "tests/**/*"]
+
+[dependencies]
+bitflags = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 #![allow(unstable)]
 #![allow(non_camel_case_types)]
 
+#[macro_use] extern crate bitflags;
+
 extern crate libc;
 extern crate core;
 


### PR DESCRIPTION
As per commit https://github.com/rust-lang/rust/commit/34fa70fba5425cbbb96bce783e9fd5c23dd9b471 , the `bitfalgs` macro has been moved to its own crate.