### PR TITLE
Add `ioctl`. Only supports the `TIOCGWINSZ` request right now.

### DIFF
--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -8,6 +8,8 @@ pub mod event;
 #[cfg(target_os = "linux")]
 pub mod eventfd;
 
+pub mod ioctl;
+
 pub mod signal;
 
 pub mod socket;


### PR DESCRIPTION
I'm using the same approach as [fcntl](https://github.com/carllerche/nix-rust/blob/da900c6932254fa5e3b2a44b3ac9160fd275d261/src/fcntl.rs#L93) (which I found to be extremely interesting).

The following code prints the correct size when running on an interactive shell on Mac and Linux.

```rust
extern crate nix;
use nix::sys::ioctl;
fn main() {
    let mut ws = ioctl::Winsize { ws_row: 0, ws_col: 0, ws_xpixel: 0, ws_ypixel: 0 };
    ioctl::ioctl(0, ioctl::TIOCGWINSZ(&mut ws)).unwrap();
    println!("{:?}", ws);
}
```