### PR TITLE
Added NONE constant to WaitPidFlag and added  unit test for fork

### DIFF
--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -11,6 +11,7 @@ mod ffi {
 
 bitflags!(
     flags WaitPidFlag: c_int {
+        const NONE = 0x00000000,
         const WNOHANG = 0x00000001,
     }
 );

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -11,7 +11,6 @@ mod ffi {
 
 bitflags!(
     flags WaitPidFlag: c_int {
-        const NONE = 0x00000000,
         const WNOHANG = 0x00000001,
     }
 );
@@ -22,12 +21,17 @@ pub enum WaitStatus {
     StillAlive
 }
 
-pub fn waitpid(pid: pid_t, options: WaitPidFlag) -> SysResult<WaitStatus> {
+pub fn waitpid(pid: pid_t, options: Option<WaitPidFlag>) -> SysResult<WaitStatus> {
     use self::WaitStatus::*;
 
     let mut status: i32 = 0;
 
-    let res = unsafe { ffi::waitpid(pid as pid_t, &mut status as *mut c_int, options.bits()) };
+    let option_bits = match options {
+        Some(bits) => bits.bits(),
+        None => 0
+    };
+
+    let res = unsafe { ffi::waitpid(pid as pid_t, &mut status as *mut c_int, option_bits) };
 
     if res < 0 {
         Err(SysError::last())

--- a/tests/unistd.rs
+++ b/tests/unistd.rs
@@ -10,7 +10,7 @@ mod test {
     use std::rand::{thread_rng, Rng};
 
     use nix::unistd::{fork};
-    use nix::sys::wait::{waitpid, NONE, WaitStatus};
+    use nix::sys::wait::{waitpid, WaitStatus};
     use nix::unistd::Fork::{Parent, Child};
 
     #[test]
@@ -110,7 +110,7 @@ mod test {
           Ok(Parent(child_pid)) => {
               // assert that child was created and pid > 0
               assert!(child_pid > 0);
-              let wait_status = waitpid(child_pid, NONE);
+              let wait_status = waitpid(child_pid, None);
               match wait_status {
                   // assert that waitpid returned correct status and the pid is the one of the child
                   Ok(WaitStatus::Exited(pid_t)) =>  assert!(pid_t == child_pid),

--- a/tests/unistd.rs
+++ b/tests/unistd.rs
@@ -9,6 +9,10 @@ mod test {
     use std::iter::repeat;
     use std::rand::{thread_rng, Rng};
 
+    use nix::unistd::{fork};
+    use nix::sys::wait::{waitpid, NONE, WaitStatus};
+    use nix::unistd::Fork::{Parent, Child};
+
     #[test]
     fn test_writev() {
         let mut to_write = Vec::with_capacity(16 * 128);
@@ -98,4 +102,29 @@ mod test {
     }
 
 
+    #[test]
+    fn test_fork_and_waitpid() {
+        let pid = fork();
+        match pid {
+          Ok(Child) => {} // ignore child here
+          Ok(Parent(child_pid)) => {
+              // assert that child was created and pid > 0
+              assert!(child_pid > 0);
+              let wait_status = waitpid(child_pid, NONE);
+              match wait_status {
+                  // assert that waitpid returned correct status and the pid is the one of the child
+                  Ok(WaitStatus::Exited(pid_t)) =>  assert!(pid_t == child_pid),
+
+                  // panic, must never happen
+                  Ok(WaitStatus::StillAlive) => panic!("Child still alive, should never happen"),
+
+                  // panic, waitpid should never fail
+                  Err(_) => panic!("Error: waitpid Failed")
+              }
+
+          },
+          // panic, fork should never fail unless there is a serious problem with the OS
+          Err(_) => panic!("Error: Fork Failed")
+        }
+    }
 }


### PR DESCRIPTION
I've added a small unit test for the fork function. I've also added "NONE" to waitpid flags so that it is possible to use it without an option (e.g. like passing 0 in the C world).

