### PR TITLE
path -> old_path

### DIFF
--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::old_path::Path;
 use libc::{c_int, mode_t};
 use errno::{SysResult, SysError};
 use sys::stat::Mode;

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -1,5 +1,5 @@
 use std::ptr;
-use std::path::Path;
+use std::old_path::Path;
 use libc::{c_ulong, c_int, c_void};
 use errno::{SysResult, from_ffi};
 use utils::ToCStr;

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -3,7 +3,7 @@ pub use libc::stat as FileStat;
 
 use std::fmt;
 use std::mem;
-use std::path::Path;
+use std::old_path::Path;
 use libc::mode_t;
 use errno::{SysResult, SysError, from_ffi};
 use fcntl::Fd;

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -426,7 +426,7 @@ pub fn isatty(fd: Fd) -> SysResult<bool> {
 
 #[cfg(target_os = "linux")]
 mod linux {
-    use std::path::Path;
+    use std::old_path::Path;
     use syscall::{syscall, SYSPIVOTROOT};
     use errno::{SysResult, SysError};
     use utils::ToCStr;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 use std::ffi::CString;
-use std::path::Path;
+use std::old_path::{Path};
 
 pub trait ToCStr {
     fn to_c_str(&self) -> CString;


### PR DESCRIPTION
The build is currently broken on nightly due to the introduction of the new Path API (which doesn't yet support conversion to `&[u8]` as far as I can see).
This fixes the build by continuing to use the old Path API.
(This should become unnecessary if #56 is merged). 
