### PR TITLE
Remove deprecated  suffixes for isize

### DIFF
--- a/src/features.rs
+++ b/src/features.rs
@@ -24,10 +24,10 @@ mod os {
             *dst += (b - b'0') as usize;
         }
 
-        let mut curr = 0us;
-        let mut major = 0;
-        let mut minor = 0;
-        let mut patch = 0;
+        let mut curr:  usize = 0;
+        let mut major: usize = 0;
+        let mut minor: usize = 0;
+        let mut patch: usize = 0;
 
         for b in u.release().bytes() {
             if curr >= 3 {

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -32,8 +32,8 @@ pub static CLONE_IO:             CloneFlags = 0x80000000;
 #[cfg(target_arch = "x86_64")]
 mod cpuset_attribs {
     use super::CpuMask;
-    pub const CPU_SETSIZE:           usize = 1024us;
-    pub const CPU_MASK_BITS:         usize = 64us;
+    pub const CPU_SETSIZE:           usize = 1024;
+    pub const CPU_MASK_BITS:         usize = 64;
 
     #[inline]
     pub fn set_cpu_mask_flag(cur: CpuMask, bit: usize) -> CpuMask {


### PR DESCRIPTION
This PR fixes some warnings that pop up due to `us` suffixes being deprecated:

```
src/features.rs:27:24: 27:27 warning: the `u` and `us` suffixes on integers are deprecated; use `usize` or one of the fixed-sized suffixes
src/features.rs:27         let mut curr = 0us;
                                          ^~~
src/features.rs:27:24: 27:27 help: add #![feature(int_uint)] to the crate attributes to silence this warning
src/features.rs:27         let mut curr = 0us;
```

Please note: the CI build will fail due to this PR not including #77