### PR TITLE
Remove hash feature declaration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![crate_name = "nix"]
 
-#![feature(collections, core, linkage, libc, hash, os, std_misc)]
+#![feature(collections, core, linkage, libc, os, std_misc)]
 #![allow(non_camel_case_types)]
 
 #[macro_use]


### PR DESCRIPTION
The `hash` feature is no longer recognised by the compiler. It would seem this declaration is no longer needed.