### PR TITLE
Rename `Nix{Error,Result}` to `{Error,Result}`.

### DIFF
--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -1,6 +1,6 @@
 use libc::mode_t;
 use errno::Errno;
-use {NixError, NixResult, NixPath};
+use {Error, Result, NixPath};
 use sys::stat::Mode;
 
 pub use self::consts::*;
@@ -71,7 +71,7 @@ mod ffi {
     }
 }
 
-pub fn open<P: NixPath>(path: P, oflag: OFlag, mode: Mode) -> NixResult<Fd> {
+pub fn open<P: NixPath>(path: P, oflag: OFlag, mode: Mode) -> Result<Fd> {
     let fd = try!(path.with_nix_path(|ptr| {
         unsafe {
             ffi::open(ptr, oflag.bits(), mode.bits() as mode_t)
@@ -79,7 +79,7 @@ pub fn open<P: NixPath>(path: P, oflag: OFlag, mode: Mode) -> NixResult<Fd> {
     }));
 
     if fd < 0 {
-        return Err(NixError::Sys(Errno::last()));
+        return Err(Error::Sys(Errno::last()));
     }
 
     Ok(fd)
@@ -106,7 +106,7 @@ pub enum FcntlArg<'a> {
 }
 
 // TODO: Figure out how to handle value fcntl returns
-pub fn fcntl(fd: Fd, arg: FcntlArg) -> NixResult<()> {
+pub fn fcntl(fd: Fd, arg: FcntlArg) -> Result<()> {
     use self::FcntlArg::*;
 
     let res = unsafe {
@@ -118,7 +118,7 @@ pub fn fcntl(fd: Fd, arg: FcntlArg) -> NixResult<()> {
     };
 
     if res < 0 {
-        return Err(NixError::Sys(Errno::last()));
+        return Err(Error::Sys(Errno::last()));
     }
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ extern crate "nix-test" as nixtest;
 pub use libc::{c_int, c_void};
 
 mod nix;
-pub use nix::{NixResult, NixError, NixPath, from_ffi};
+pub use nix::{Result, Error, NixPath, from_ffi};
 
 #[cfg(unix)]
 pub mod errno;

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -1,5 +1,5 @@
 use libc::{c_ulong, c_int, c_void};
-use {NixResult, NixPath, from_ffi};
+use {Result, NixPath, from_ffi};
 
 bitflags!(
     flags MsFlags: c_ulong {
@@ -71,7 +71,7 @@ pub fn mount<P1: NixPath, P2: NixPath, P3: NixPath, P4: NixPath>(
         target: P2,
         fstype: Option<P3>,
         flags: MsFlags,
-        data: Option<P4>) -> NixResult<()> {
+        data: Option<P4>) -> Result<()> {
     use libc;
 
     let res = try!(try!(try!(try!(
@@ -94,7 +94,7 @@ pub fn mount<P1: NixPath, P2: NixPath, P3: NixPath, P4: NixPath>(
     return from_ffi(res);
 }
 
-pub fn umount<P: NixPath>(target: P) -> NixResult<()> {
+pub fn umount<P: NixPath>(target: P) -> Result<()> {
     let res = try!(target.with_nix_path(|ptr| {
         unsafe { ffi::umount(ptr) }
     }));
@@ -102,7 +102,7 @@ pub fn umount<P: NixPath>(target: P) -> NixResult<()> {
     from_ffi(res)
 }
 
-pub fn umount2<P: NixPath>(target: P, flags: MntFlags) -> NixResult<()> {
+pub fn umount2<P: NixPath>(target: P, flags: MntFlags) -> Result<()> {
     let res = try!(target.with_nix_path(|ptr| {
         unsafe { ffi::umount2(ptr, flags.bits) }
     }));

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -1,7 +1,7 @@
 use std::mem;
 use libc::{c_int, c_uint, c_void, c_ulong};
 use errno::Errno;
-use {NixResult, NixError};
+use {Result, Error};
 
 pub type CloneFlags = c_uint;
 
@@ -124,7 +124,7 @@ mod ffi {
     }
 }
 
-pub fn sched_setaffinity(pid: isize, cpuset: &CpuSet) -> NixResult<()> {
+pub fn sched_setaffinity(pid: isize, cpuset: &CpuSet) -> Result<()> {
     use libc::{pid_t, size_t};
 
     let res = unsafe {
@@ -132,13 +132,13 @@ pub fn sched_setaffinity(pid: isize, cpuset: &CpuSet) -> NixResult<()> {
     };
 
     if res != 0 {
-        Err(NixError::Sys(Errno::last()))
+        Err(Error::Sys(Errno::last()))
     } else {
         Ok(())
     }
 }
 
-pub fn clone(mut cb: CloneCb, stack: &mut [u8], flags: CloneFlags) -> NixResult<()> {
+pub fn clone(mut cb: CloneCb, stack: &mut [u8], flags: CloneFlags) -> Result<()> {
     extern "C" fn callback(data: *mut CloneCb) -> c_int {
         let cb: &mut CloneCb = unsafe { &mut *data };
         (*cb)() as c_int
@@ -150,17 +150,17 @@ pub fn clone(mut cb: CloneCb, stack: &mut [u8], flags: CloneFlags) -> NixResult<
     };
 
     if res != 0 {
-        return Err(NixError::Sys(Errno::last()));
+        return Err(Error::Sys(Errno::last()));
     }
 
     Ok(())
 }
 
-pub fn unshare(flags: CloneFlags) -> NixResult<()> {
+pub fn unshare(flags: CloneFlags) -> Result<()> {
     let res = unsafe { ffi::unshare(flags) };
 
     if res != 0 {
-        return Err(NixError::Sys(Errno::last()));
+        return Err(Error::Sys(Errno::last()));
     }
 
     Ok(())

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use libc::c_int;
 use errno::Errno;
-use {NixError, NixResult, from_ffi};
+use {Error, Result, from_ffi};
 use fcntl::Fd;
 
 mod ffi {
@@ -86,30 +86,30 @@ pub struct EpollEvent {
 }
 
 #[inline]
-pub fn epoll_create() -> NixResult<Fd> {
+pub fn epoll_create() -> Result<Fd> {
     let res = unsafe { ffi::epoll_create(1024) };
 
     if res < 0 {
-        return Err(NixError::Sys(Errno::last()));
+        return Err(Error::Sys(Errno::last()));
     }
 
     Ok(res)
 }
 
 #[inline]
-pub fn epoll_ctl(epfd: Fd, op: EpollOp, fd: Fd, event: &EpollEvent) -> NixResult<()> {
+pub fn epoll_ctl(epfd: Fd, op: EpollOp, fd: Fd, event: &EpollEvent) -> Result<()> {
     let res = unsafe { ffi::epoll_ctl(epfd, op as c_int, fd, event as *const EpollEvent) };
     from_ffi(res)
 }
 
 #[inline]
-pub fn epoll_wait(epfd: Fd, events: &mut [EpollEvent], timeout_ms: usize) -> NixResult<usize> {
+pub fn epoll_wait(epfd: Fd, events: &mut [EpollEvent], timeout_ms: usize) -> Result<usize> {
     let res = unsafe {
         ffi::epoll_wait(epfd, events.as_mut_ptr(), events.len() as c_int, timeout_ms as c_int)
     };
 
     if res < 0 {
-        return Err(NixError::Sys(Errno::last()));
+        return Err(Error::Sys(Errno::last()));
     }
 
     Ok(res as usize)

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -5,7 +5,7 @@ use libc::{timespec, time_t, c_int, c_long, uintptr_t};
 use errno::Errno;
 use fcntl::Fd;
 use std::fmt;
-use {NixError, NixResult};
+use {Error, Result};
 
 pub use self::ffi::kevent as KEvent;
 
@@ -159,11 +159,11 @@ bitflags!(
 pub const EV_POLL: EventFlag = EV_FLAG0;
 pub const EV_OOBAND: EventFlag = EV_FLAG1;
 
-pub fn kqueue() -> NixResult<Fd> {
+pub fn kqueue() -> Result<Fd> {
     let res = unsafe { ffi::kqueue() };
 
     if res < 0 {
-        return Err(NixError::Sys(Errno::last()));
+        return Err(Error::Sys(Errno::last()));
     }
 
     Ok(res)
@@ -172,7 +172,7 @@ pub fn kqueue() -> NixResult<Fd> {
 pub fn kevent(kq: Fd,
               changelist: &[KEvent],
               eventlist: &mut [KEvent],
-              timeout_ms: usize) -> NixResult<usize> {
+              timeout_ms: usize) -> Result<usize> {
 
     // Convert ms to timespec
     let timeout = timespec {
@@ -191,7 +191,7 @@ pub fn kevent(kq: Fd,
     };
 
     if res < 0 {
-        return Err(NixError::Sys(Errno::last()));
+        return Err(Error::Sys(Errno::last()));
     }
 
     return Ok(res as usize)

--- a/src/sys/eventfd.rs
+++ b/src/sys/eventfd.rs
@@ -2,7 +2,7 @@ use std::mem;
 use libc::{c_int, c_uint};
 use errno::Errno;
 use fcntl::Fd;
-use {NixError, NixResult};
+use {Error, Result};
 
 bitflags!(
     flags EventFdFlag: c_int {
@@ -12,7 +12,7 @@ bitflags!(
     }
 );
 
-pub fn eventfd(initval: usize, flags: EventFdFlag) -> NixResult<Fd> {
+pub fn eventfd(initval: usize, flags: EventFdFlag) -> Result<Fd> {
     type F = unsafe extern "C" fn(initval: c_uint, flags: c_int) -> c_int;
 
     extern {
@@ -30,7 +30,7 @@ pub fn eventfd(initval: usize, flags: EventFdFlag) -> NixResult<Fd> {
     };
 
     if res < 0 {
-        return Err(NixError::Sys(Errno::last()));
+        return Err(Error::Sys(Errno::last()));
     }
 
     Ok(res)

--- a/src/sys/ioctl.rs
+++ b/src/sys/ioctl.rs
@@ -1,6 +1,6 @@
 use libc;
 use fcntl::Fd;
-use {NixResult, from_ffi};
+use {Result, from_ffi};
 
 pub use self::ffi::Winsize;
 pub use self::IoctlArg::*;
@@ -33,7 +33,7 @@ pub enum IoctlArg<'a> {
     TIOCGWINSZ(&'a mut Winsize)
 }
 
-pub fn ioctl(fd: Fd, arg: IoctlArg) -> NixResult<()> {
+pub fn ioctl(fd: Fd, arg: IoctlArg) -> Result<()> {
     match arg {
         TIOCGWINSZ(&mut ref winsize) => {
             from_ffi(unsafe {

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -2,7 +2,7 @@ use errno::Errno;
 use fcntl::{Fd, OFlag};
 use libc::{c_void, size_t, off_t, mode_t};
 use sys::stat::Mode;
-use {NixError, NixResult, NixPath};
+use {Error, Result, NixPath};
 
 pub use self::consts::*;
 
@@ -128,54 +128,54 @@ mod ffi {
     }
 }
 
-pub unsafe fn mlock(addr: *const c_void, length: size_t) -> NixResult<()> {
+pub unsafe fn mlock(addr: *const c_void, length: size_t) -> Result<()> {
     match ffi::mlock(addr, length) {
         0 => Ok(()),
-        _ => Err(NixError::Sys(Errno::last()))
+        _ => Err(Error::Sys(Errno::last()))
     }
 }
 
-pub fn munlock(addr: *const c_void, length: size_t) -> NixResult<()> {
+pub fn munlock(addr: *const c_void, length: size_t) -> Result<()> {
     match unsafe { ffi::munlock(addr, length) } {
         0 => Ok(()),
-        _ => Err(NixError::Sys(Errno::last()))
+        _ => Err(Error::Sys(Errno::last()))
     }
 }
 
 /// Calls to mmap are inherently unsafe, so they must be made in an unsafe block. Typically
 /// a higher-level abstraction will hide the unsafe interactions with the mmap'd region.
-pub fn mmap(addr: *mut c_void, length: size_t, prot: MmapProt, flags: MmapFlag, fd: Fd, offset: off_t) -> NixResult<*mut c_void> {
+pub fn mmap(addr: *mut c_void, length: size_t, prot: MmapProt, flags: MmapFlag, fd: Fd, offset: off_t) -> Result<*mut c_void> {
     let ret = unsafe { ffi::mmap(addr, length, prot, flags, fd, offset) };
 
     if ret as isize == MAP_FAILED  {
-        Err(NixError::Sys(Errno::last()))
+        Err(Error::Sys(Errno::last()))
     } else {
         Ok(ret)
     }
 }
 
-pub fn munmap(addr: *mut c_void, len: size_t) -> NixResult<()> {
+pub fn munmap(addr: *mut c_void, len: size_t) -> Result<()> {
     match unsafe { ffi::munmap(addr, len) } {
         0 => Ok(()),
-        _ => Err(NixError::Sys(Errno::last()))
+        _ => Err(Error::Sys(Errno::last()))
     }
 }
 
-pub fn madvise(addr: *const c_void, length: size_t, advise: MmapAdvise) -> NixResult<()> {
+pub fn madvise(addr: *const c_void, length: size_t, advise: MmapAdvise) -> Result<()> {
     match unsafe { ffi::madvise(addr, length, advise) } {
         0 => Ok(()),
-        _ => Err(NixError::Sys(Errno::last()))
+        _ => Err(Error::Sys(Errno::last()))
     }
 }
 
-pub fn msync(addr: *const c_void, length: size_t, flags: MmapSync) -> NixResult<()> {
+pub fn msync(addr: *const c_void, length: size_t, flags: MmapSync) -> Result<()> {
     match unsafe { ffi::msync(addr, length, flags) } {
         0 => Ok(()),
-        _ => Err(NixError::Sys(Errno::last()))
+        _ => Err(Error::Sys(Errno::last()))
     }
 }
 
-pub fn shm_open<P: NixPath>(name: P, flag: OFlag, mode: Mode) -> NixResult<Fd> {
+pub fn shm_open<P: NixPath>(name: P, flag: OFlag, mode: Mode) -> Result<Fd> {
     let ret = try!(name.with_nix_path(|ptr| {
         unsafe {
             ffi::shm_open(ptr, flag.bits(), mode.bits() as mode_t)
@@ -183,19 +183,19 @@ pub fn shm_open<P: NixPath>(name: P, flag: OFlag, mode: Mode) -> NixResult<Fd> {
     }));
 
     if ret < 0 {
-        Err(NixError::Sys(Errno::last()))
+        Err(Error::Sys(Errno::last()))
     } else {
         Ok(ret)
     }
 }
 
-pub fn shm_unlink<P: NixPath>(name: P) -> NixResult<()> {
+pub fn shm_unlink<P: NixPath>(name: P) -> Result<()> {
     let ret = try!(name.with_nix_path(|ptr| {
         unsafe { ffi::shm_unlink(ptr) }
     }));
 
     if ret < 0 {
-        Err(NixError::Sys(Errno::last()))
+        Err(Error::Sys(Errno::last()))
     } else {
         Ok(())
     }

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -4,7 +4,7 @@
 use libc;
 use errno::Errno;
 use core::mem;
-use {NixError, NixResult};
+use {Error, Result};
 
 pub use libc::consts::os::posix88::{
     SIGHUP,   // 1
@@ -312,21 +312,21 @@ impl SigSet {
         SigSet { sigset: sigset }
     }
 
-    pub fn add(&mut self, signum: SigNum) -> NixResult<()> {
+    pub fn add(&mut self, signum: SigNum) -> Result<()> {
         let res = unsafe { ffi::sigaddset(&mut self.sigset as *mut sigset_t, signum) };
 
         if res < 0 {
-            return Err(NixError::Sys(Errno::last()));
+            return Err(Error::Sys(Errno::last()));
         }
 
         Ok(())
     }
 
-    pub fn remove(&mut self, signum: SigNum) -> NixResult<()> {
+    pub fn remove(&mut self, signum: SigNum) -> Result<()> {
         let res = unsafe { ffi::sigdelset(&mut self.sigset as *mut sigset_t, signum) };
 
         if res < 0 {
-            return Err(NixError::Sys(Errno::last()));
+            return Err(Error::Sys(Errno::last()));
         }
 
         Ok(())
@@ -350,7 +350,7 @@ impl SigAction {
     }
 }
 
-pub fn sigaction(signum: SigNum, sigaction: &SigAction) -> NixResult<SigAction> {
+pub fn sigaction(signum: SigNum, sigaction: &SigAction) -> Result<SigAction> {
     let mut oldact = unsafe { mem::uninitialized::<sigaction_t>() };
 
     let res = unsafe {
@@ -358,17 +358,17 @@ pub fn sigaction(signum: SigNum, sigaction: &SigAction) -> NixResult<SigAction> 
     };
 
     if res < 0 {
-        return Err(NixError::Sys(Errno::last()));
+        return Err(Error::Sys(Errno::last()));
     }
 
     Ok(SigAction { sigaction: oldact })
 }
 
-pub fn kill(pid: libc::pid_t, signum: SigNum) -> NixResult<()> {
+pub fn kill(pid: libc::pid_t, signum: SigNum) -> Result<()> {
     let res = unsafe { ffi::kill(pid, signum) };
 
     if res < 0 {
-        return Err(NixError::Sys(Errno::last()));
+        return Err(Error::Sys(Errno::last()));
     }
 
     Ok(())

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -2,7 +2,7 @@ use errno::Errno;
 use fcntl::Fd;
 use libc::c_int;
 use std::mem;
-use {NixError, NixResult, from_ffi};
+use {Error, Result, from_ffi};
 
 pub use self::ffi::consts::*;
 pub use self::ffi::consts::SetArg::*;
@@ -362,19 +362,19 @@ pub fn cfgetospeed(termios: &Termios) -> speed_t {
     }
 }
 
-pub fn cfsetispeed(termios: &mut Termios, speed: speed_t) -> NixResult<()> {
+pub fn cfsetispeed(termios: &mut Termios, speed: speed_t) -> Result<()> {
     from_ffi(unsafe {
         ffi::cfsetispeed(termios, speed)
     })
 }
 
-pub fn cfsetospeed(termios: &mut Termios, speed: speed_t) -> NixResult<()> {
+pub fn cfsetospeed(termios: &mut Termios, speed: speed_t) -> Result<()> {
     from_ffi(unsafe {
         ffi::cfsetospeed(termios, speed)
     })
 }
 
-pub fn tcgetattr(fd: Fd) -> NixResult<Termios> {
+pub fn tcgetattr(fd: Fd) -> Result<Termios> {
     let mut termios = unsafe { mem::uninitialized() };
 
     let res = unsafe {
@@ -382,7 +382,7 @@ pub fn tcgetattr(fd: Fd) -> NixResult<Termios> {
     };
 
     if res < 0 {
-        return Err(NixError::Sys(Errno::last()));
+        return Err(Error::Sys(Errno::last()));
     }
 
     Ok(termios)
@@ -390,31 +390,31 @@ pub fn tcgetattr(fd: Fd) -> NixResult<Termios> {
 
 pub fn tcsetattr(fd: Fd,
                  actions: SetArg,
-                 termios: &Termios) -> NixResult<()> {
+                 termios: &Termios) -> Result<()> {
     from_ffi(unsafe {
         ffi::tcsetattr(fd, actions as c_int, termios)
     })
 }
 
-pub fn tcdrain(fd: Fd) -> NixResult<()> {
+pub fn tcdrain(fd: Fd) -> Result<()> {
     from_ffi(unsafe {
         ffi::tcdrain(fd)
     })
 }
 
-pub fn tcflow(fd: Fd, action: FlowArg) -> NixResult<()> {
+pub fn tcflow(fd: Fd, action: FlowArg) -> Result<()> {
     from_ffi(unsafe {
         ffi::tcflow(fd, action as c_int)
     })
 }
 
-pub fn tcflush(fd: Fd, action: FlushArg) -> NixResult<()> {
+pub fn tcflush(fd: Fd, action: FlushArg) -> Result<()> {
     from_ffi(unsafe {
         ffi::tcflush(fd, action as c_int)
     })
 }
 
-pub fn tcsendbreak(fd: Fd, action: c_int) -> NixResult<()> {
+pub fn tcsendbreak(fd: Fd, action: c_int) -> Result<()> {
     from_ffi(unsafe {
         ffi::tcsendbreak(fd, action)
     })

--- a/src/sys/uio.rs
+++ b/src/sys/uio.rs
@@ -12,20 +12,20 @@ mod ffi {
     pub fn readv(fd: Fd, iov: *const IoVec<&mut [u8]>, iovcnt: c_int) -> ssize_t;
 }
 
-pub fn writev(fd: Fd, iov: &[IoVec<&[u8]>]) -> NixResult<usize> {
+pub fn writev(fd: Fd, iov: &[IoVec<&[u8]>]) -> Result<usize> {
     let res = unsafe { ffi::writev(fd, iov.as_ptr(), iov.len() as c_int) };
 
     if res < 0 {
-        return Err(NixError::Sys(Errno::last()));
+        return Err(Error::Sys(Errno::last()));
     }
 
     return Ok(res as usize)
 }
 
-pub fn readv(fd: Fd, iov: &mut [IoVec<&mut [u8]>]) -> NixResult<usize> {
+pub fn readv(fd: Fd, iov: &mut [IoVec<&mut [u8]>]) -> Result<usize> {
     let res = unsafe { ffi::readv(fd, iov.as_ptr(), iov.len() as c_int) };
     if res < 0 {
-        return Err(NixError::Sys(Errno::last()));
+        return Err(Error::Sys(Errno::last()));
     }
 
     return Ok(res as usize)

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -1,6 +1,6 @@
 use libc::{pid_t, c_int};
 use errno::Errno;
-use {NixError, NixResult};
+use {Error, Result};
 
 mod ffi {
     use libc::{pid_t, c_int};
@@ -22,7 +22,7 @@ pub enum WaitStatus {
     StillAlive
 }
 
-pub fn waitpid(pid: pid_t, options: Option<WaitPidFlag>) -> NixResult<WaitStatus> {
+pub fn waitpid(pid: pid_t, options: Option<WaitPidFlag>) -> Result<WaitStatus> {
     use self::WaitStatus::*;
 
     let mut status: i32 = 0;
@@ -35,7 +35,7 @@ pub fn waitpid(pid: pid_t, options: Option<WaitPidFlag>) -> NixResult<WaitStatus
     let res = unsafe { ffi::waitpid(pid as pid_t, &mut status as *mut c_int, option_bits) };
 
     if res < 0 {
-        Err(NixError::Sys(Errno::last()))
+        Err(Error::Sys(Errno::last()))
     } else if res == 0 {
         Ok(StillAlive)
     } else {

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1,4 +1,4 @@
-use {NixError, NixResult, NixPath, from_ffi};
+use {Error, Result, NixPath, from_ffi};
 use errno::Errno;
 use fcntl::{fcntl, Fd, OFlag, O_NONBLOCK, O_CLOEXEC, FD_CLOEXEC};
 use fcntl::FcntlArg::{F_SETFD, F_SETFL};
@@ -64,13 +64,13 @@ impl Fork {
     }
 }
 
-pub fn fork() -> NixResult<Fork> {
+pub fn fork() -> Result<Fork> {
     use self::Fork::*;
 
     let res = unsafe { ffi::fork() };
 
     if res < 0 {
-        return Err(NixError::Sys(Errno::last()));
+        return Err(Error::Sys(Errno::last()));
     } else if res == 0 {
         Ok(Child)
     } else {
@@ -79,29 +79,29 @@ pub fn fork() -> NixResult<Fork> {
 }
 
 #[inline]
-pub fn dup(oldfd: Fd) -> NixResult<Fd> {
+pub fn dup(oldfd: Fd) -> Result<Fd> {
     let res = unsafe { ffi::dup(oldfd) };
 
     if res < 0 {
-        return Err(NixError::Sys(Errno::last()));
+        return Err(Error::Sys(Errno::last()));
     }
 
     Ok(res)
 }
 
 #[inline]
-pub fn dup2(oldfd: Fd, newfd: Fd) -> NixResult<Fd> {
+pub fn dup2(oldfd: Fd, newfd: Fd) -> Result<Fd> {
     let res = unsafe { ffi::dup2(oldfd, newfd) };
 
     if res < 0 {
-        return Err(NixError::Sys(Errno::last()));
+        return Err(Error::Sys(Errno::last()));
     }
 
     Ok(res)
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "ios")))]
-pub fn dup3(oldfd: Fd, newfd: Fd, flags: OFlag) -> NixResult<Fd> {
+pub fn dup3(oldfd: Fd, newfd: Fd, flags: OFlag) -> Result<Fd> {
     type F = unsafe extern "C" fn(c_int, c_int, c_int) -> c_int;
 
     extern {
@@ -116,7 +116,7 @@ pub fn dup3(oldfd: Fd, newfd: Fd, flags: OFlag) -> NixResult<Fd> {
         };
 
         if res < 0 {
-            return Err(NixError::Sys(Errno::last()));
+            return Err(Error::Sys(Errno::last()));
         }
 
         Ok(res)
@@ -126,16 +126,16 @@ pub fn dup3(oldfd: Fd, newfd: Fd, flags: OFlag) -> NixResult<Fd> {
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
-pub fn dup3(oldfd: Fd, newfd: Fd, flags: OFlag) -> NixResult<Fd> {
+pub fn dup3(oldfd: Fd, newfd: Fd, flags: OFlag) -> Result<Fd> {
     dup3_polyfill(oldfd, newfd, flags)
 }
 
 #[inline]
-fn dup3_polyfill(oldfd: Fd, newfd: Fd, flags: OFlag) -> NixResult<Fd> {
+fn dup3_polyfill(oldfd: Fd, newfd: Fd, flags: OFlag) -> Result<Fd> {
     use errno::EINVAL;
 
     if oldfd == newfd {
-        return Err(NixError::Sys(Errno::EINVAL));
+        return Err(Error::Sys(Errno::EINVAL));
     }
 
     let fd = try!(dup2(oldfd, newfd));
@@ -151,20 +151,20 @@ fn dup3_polyfill(oldfd: Fd, newfd: Fd, flags: OFlag) -> NixResult<Fd> {
 }
 
 #[inline]
-pub fn chdir<P: NixPath>(path: P) -> NixResult<()> {
+pub fn chdir<P: NixPath>(path: P) -> Result<()> {
     let res = try!(path.with_nix_path(|ptr| {
         unsafe { ffi::chdir(ptr) }
     }));
 
     if res != 0 {
-        return Err(NixError::Sys(Errno::last()));
+        return Err(Error::Sys(Errno::last()));
     }
 
     return Ok(())
 }
 
 #[inline]
-pub fn execve(filename: &CString, args: &[CString], env: &[CString]) -> NixResult<()> {
+pub fn execve(filename: &CString, args: &[CString], env: &[CString]) -> Result<()> {
     let mut args_p: Vec<*const c_char> = args.iter().map(|s| s.as_ptr()).collect();
     args_p.push(ptr::null());
 
@@ -176,18 +176,18 @@ pub fn execve(filename: &CString, args: &[CString], env: &[CString]) -> NixResul
     };
 
     if res != 0 {
-        return Err(NixError::Sys(Errno::last()));
+        return Err(Error::Sys(Errno::last()));
     }
 
     unreachable!()
 }
 
-pub fn daemon(nochdir: bool, noclose: bool) -> NixResult<()> {
+pub fn daemon(nochdir: bool, noclose: bool) -> Result<()> {
     let res = unsafe { ffi::daemon(nochdir as c_int, noclose as c_int) };
     from_ffi(res)
 }
 
-pub fn sethostname(name: &[u8]) -> NixResult<()> {
+pub fn sethostname(name: &[u8]) -> Result<()> {
     let ptr = name.as_ptr() as *const c_char;
     let len = name.len() as size_t;
 
@@ -195,7 +195,7 @@ pub fn sethostname(name: &[u8]) -> NixResult<()> {
     from_ffi(res)
 }
 
-pub fn gethostname(name: &mut [u8]) -> NixResult<()> {
+pub fn gethostname(name: &mut [u8]) -> Result<()> {
     let ptr = name.as_mut_ptr() as *mut c_char;
     let len = name.len() as size_t;
 
@@ -203,32 +203,32 @@ pub fn gethostname(name: &mut [u8]) -> NixResult<()> {
     from_ffi(res)
 }
 
-pub fn close(fd: Fd) -> NixResult<()> {
+pub fn close(fd: Fd) -> Result<()> {
     let res = unsafe { ffi::close(fd) };
     from_ffi(res)
 }
 
-pub fn read(fd: Fd, buf: &mut [u8]) -> NixResult<usize> {
+pub fn read(fd: Fd, buf: &mut [u8]) -> Result<usize> {
     let res = unsafe { ffi::read(fd, buf.as_mut_ptr() as *mut c_void, buf.len() as size_t) };
 
     if res < 0 {
-        return Err(NixError::Sys(Errno::last()));
+        return Err(Error::Sys(Errno::last()));
     }
 
     return Ok(res as usize)
 }
 
-pub fn write(fd: Fd, buf: &[u8]) -> NixResult<usize> {
+pub fn write(fd: Fd, buf: &[u8]) -> Result<usize> {
     let res = unsafe { ffi::write(fd, buf.as_ptr() as *const c_void, buf.len() as size_t) };
 
     if res < 0 {
-        return Err(NixError::Sys(Errno::last()));
+        return Err(Error::Sys(Errno::last()));
     }
 
     return Ok(res as usize)
 }
 
-pub fn pipe() -> NixResult<(Fd, Fd)> {
+pub fn pipe() -> Result<(Fd, Fd)> {
     unsafe {
         let mut res;
         let mut fds: [c_int; 2] = mem::uninitialized();
@@ -236,7 +236,7 @@ pub fn pipe() -> NixResult<(Fd, Fd)> {
         res = ffi::pipe(fds.as_mut_ptr());
 
         if res < 0 {
-            return Err(NixError::Sys(Errno::last()));
+            return Err(Error::Sys(Errno::last()));
         }
 
         Ok((fds[0], fds[1]))
@@ -244,7 +244,7 @@ pub fn pipe() -> NixResult<(Fd, Fd)> {
 }
 
 #[cfg(target_os = "linux")]
-pub fn pipe2(flags: OFlag) -> NixResult<(Fd, Fd)> {
+pub fn pipe2(flags: OFlag) -> Result<(Fd, Fd)> {
     type F = unsafe extern "C" fn(fds: *mut c_int, flags: c_int) -> c_int;
 
     extern {
@@ -266,7 +266,7 @@ pub fn pipe2(flags: OFlag) -> NixResult<(Fd, Fd)> {
         }
 
         if res < 0 {
-            return Err(NixError::Sys(Errno::last()));
+            return Err(Error::Sys(Errno::last()));
         }
 
         if !feat_atomic {
@@ -278,7 +278,7 @@ pub fn pipe2(flags: OFlag) -> NixResult<(Fd, Fd)> {
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
-pub fn pipe2(flags: OFlag) -> NixResult<(Fd, Fd)> {
+pub fn pipe2(flags: OFlag) -> Result<(Fd, Fd)> {
     unsafe {
         let mut res;
         let mut fds: [c_int; 2] = mem::uninitialized();
@@ -286,7 +286,7 @@ pub fn pipe2(flags: OFlag) -> NixResult<(Fd, Fd)> {
         res = ffi::pipe(fds.as_mut_ptr());
 
         if res < 0 {
-            return Err(NixError::Sys(Errno::last()));
+            return Err(Error::Sys(Errno::last()));
         }
 
         try!(pipe2_setflags(fds[0], fds[1], flags));
@@ -295,7 +295,7 @@ pub fn pipe2(flags: OFlag) -> NixResult<(Fd, Fd)> {
     }
 }
 
-fn pipe2_setflags(fd1: Fd, fd2: Fd, flags: OFlag) -> NixResult<()> {
+fn pipe2_setflags(fd1: Fd, fd2: Fd, flags: OFlag) -> Result<()> {
     let mut res = Ok(());
 
     if flags.contains(O_CLOEXEC) {
@@ -320,15 +320,15 @@ fn pipe2_setflags(fd1: Fd, fd2: Fd, flags: OFlag) -> NixResult<()> {
     }
 }
 
-pub fn ftruncate(fd: Fd, len: off_t) -> NixResult<()> {
+pub fn ftruncate(fd: Fd, len: off_t) -> Result<()> {
     if unsafe { ffi::ftruncate(fd, len) } < 0 {
-        Err(NixError::Sys(Errno::last()))
+        Err(Error::Sys(Errno::last()))
     } else {
         Ok(())
     }
 }
 
-pub fn isatty(fd: Fd) -> NixResult<bool> {
+pub fn isatty(fd: Fd) -> Result<bool> {
     use libc;
 
     if unsafe { libc::isatty(fd) } == 1 {
@@ -338,12 +338,12 @@ pub fn isatty(fd: Fd) -> NixResult<bool> {
             // ENOTTY means `fd` is a valid file descriptor, but not a TTY, so
             // we return `Ok(false)`
             Errno::ENOTTY => Ok(false),
-            err => Err(NixError::Sys(err))
+            err => Err(Error::Sys(err))
         }
     }
 }
 
-pub fn unlink<P: NixPath>(path: P) -> NixResult<()> {
+pub fn unlink<P: NixPath>(path: P) -> Result<()> {
     let res = try!(path.with_nix_path(|ptr| {
     unsafe {
         ffi::unlink(ptr)
@@ -356,10 +356,10 @@ pub fn unlink<P: NixPath>(path: P) -> NixResult<()> {
 mod linux {
     use syscall::{syscall, SYSPIVOTROOT};
     use errno::Errno;
-    use {NixError, NixResult, NixPath};
+    use {Error, Result, NixPath};
 
     pub fn pivot_root<P1: NixPath, P2: NixPath>(new_root: P1,
-                                                put_old: P2) -> NixResult<()> {
+                                                put_old: P2) -> Result<()> {
         let res = try!(try!(new_root.with_nix_path(|new_root| {
             put_old.with_nix_path(|put_old| {
                 unsafe {
@@ -369,7 +369,7 @@ mod linux {
         })));
 
         if res != 0 {
-            return Err(NixError::Sys(Errno::last()));
+            return Err(Error::Sys(Errno::last()));
         }
 
         Ok(())

--- a/test/sys/test_termios.rs
+++ b/test/sys/test_termios.rs
@@ -1,6 +1,6 @@
 use nix::errno::Errno;
 use nix::sys::termios;
-use nix::{NixError, unistd};
+use nix::{Error, unistd};
 
 #[test]
 fn test_tcgetattr() {
@@ -11,8 +11,8 @@ fn test_tcgetattr() {
             Ok(true) => assert!(termios.is_ok()),
             // If it's an invalid file descriptor, tcgetattr should also return
             // the same error
-            Err(NixError::Sys(Errno::EBADF)) => {
-                assert!(termios.err() == Some(NixError::Sys(Errno::EBADF)));
+            Err(Error::Sys(Errno::EBADF)) => {
+                assert!(termios.err() == Some(Error::Sys(Errno::EBADF)));
             },
             // Otherwise it should return any error
             _ => assert!(termios.is_err())


### PR DESCRIPTION
Fixes #82.

Surprisingly, this took only a minute for doing a global search/replace and changing 4 lines in `src/nix.rs`. The `use Result` in every file is shadowing the `Result` in the prelude I believe.