### PR TITLE
Make `sigaction` unsafe

### DIFF
--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -350,12 +350,11 @@ impl SigAction {
     }
 }
 
-pub fn sigaction(signum: SigNum, sigaction: &SigAction) -> Result<SigAction> {
-    let mut oldact = unsafe { mem::uninitialized::<sigaction_t>() };
+pub unsafe fn sigaction(signum: SigNum, sigaction: &SigAction) -> Result<SigAction> {
+    let mut oldact = mem::uninitialized::<sigaction_t>();
 
-    let res = unsafe {
-        ffi::sigaction(signum, &sigaction.sigaction as *const sigaction_t, &mut oldact as *mut sigaction_t)
-    };
+    let res =
+        ffi::sigaction(signum, &sigaction.sigaction as *const sigaction_t, &mut oldact as *mut sigaction_t);
 
     if res < 0 {
         return Err(Error::Sys(Errno::last()));


### PR DESCRIPTION
This is done because interrupted execution has soundness bugs regarding
thread-local storage. Fixes #90.