### PR TITLE
sched: add support for arm linux using same cpuset_attribs as android

### DIFF
--- a/src/sched.rs
+++ b/src/sched.rs
@@ -63,7 +63,7 @@ mod cpuset_attribs {
     }
 }
 
-#[cfg(all(target_arch = "arm", target_os = "android"))]
+#[cfg(all(target_arch = "arm", any(target_os = "linux", target_os = "android")))]
 mod cpuset_attribs {
     use super::CpuMask;
     // bionic only supports up to 32 independent CPUs, instead of 1024.


### PR DESCRIPTION
The limit of 32 cores may not actually be a limit with arm-linux, but
I am not aware of anything in excess of 32 processors out there currently
and this is what I have been running for awhile now on a beaglebone
black (`--target=arm-unknown-linux-gnueabihf`).

This change addresses #95 and relates to #97.