### PR TITLE
Fix AsExtStr to return CStrings

### DIFF
--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -73,7 +73,8 @@ mod ffi {
 
 pub fn open<P: ?Sized + NixPath>(path: &P, oflag: OFlag, mode: Mode) -> Result<Fd> {
     let fd = try!(path.with_nix_path(|osstr| {
-        unsafe { ffi::open(osstr.as_ext_str(), oflag.bits(), mode.bits() as mode_t) }
+        let cstr = try!(osstr.as_ext_str());
+        Ok(unsafe { ffi::open(cstr.as_ptr(), oflag.bits(), mode.bits() as mode_t) })
     }));
 
     if fd < 0 {

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -101,16 +101,18 @@ pub fn mount<P1: ?Sized + NixPath, P2: ?Sized + NixPath, P3: ?Sized + NixPath, P
 */
 
 pub fn umount<P: ?Sized + NixPath>(target: &P) -> Result<()> {
-    let res = try!(target.with_nix_path(|ptr| {
-        unsafe { ffi::umount(ptr.as_ext_str()) }
+    let res = try!(target.with_nix_path(|osstr| {
+        let cstr = try!(osstr.as_ext_str());
+        Ok(unsafe { ffi::umount(cstr.as_ptr()) })
     }));
 
     from_ffi(res)
 }
 
 pub fn umount2<P: ?Sized + NixPath>(target: &P, flags: MntFlags) -> Result<()> {
-    let res = try!(target.with_nix_path(|ptr| {
-        unsafe { ffi::umount2(ptr.as_ext_str(), flags.bits) }
+    let res = try!(target.with_nix_path(|osstr| {
+        let cstr = try!(osstr.as_ext_str());
+        Ok(unsafe { ffi::umount2(cstr.as_ptr(), flags.bits) })
     }));
 
     from_ffi(res)

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -226,9 +226,10 @@ pub fn msync(addr: *const c_void, length: size_t, flags: MmapSync) -> Result<()>
 
 pub fn shm_open<P: ?Sized + NixPath>(name: &P, flag: OFlag, mode: Mode) -> Result<Fd> {
     let ret = try!(name.with_nix_path(|osstr| {
-        unsafe {
-            ffi::shm_open(osstr.as_ext_str(), flag.bits(), mode.bits() as mode_t)
-        }
+        let cstr = try!(osstr.as_ext_str());
+        Ok(unsafe {
+            ffi::shm_open(cstr.as_ptr(), flag.bits(), mode.bits() as mode_t)
+        })
     }));
 
     if ret < 0 {
@@ -240,7 +241,8 @@ pub fn shm_open<P: ?Sized + NixPath>(name: &P, flag: OFlag, mode: Mode) -> Resul
 
 pub fn shm_unlink<P: ?Sized + NixPath>(name: &P) -> Result<()> {
     let ret = try!(name.with_nix_path(|osstr| {
-        unsafe { ffi::shm_unlink(osstr.as_ext_str()) }
+        let cstr = try!(osstr.as_ext_str());
+        Ok(unsafe { ffi::shm_unlink(cstr.as_ptr()) })
     }));
 
     if ret < 0 {

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -334,7 +334,7 @@ pub struct UnixAddr(pub libc::sockaddr_un);
 
 impl UnixAddr {
     pub fn new<P: ?Sized + NixPath>(path: &P) -> Result<UnixAddr> {
-        try!(path.with_nix_path(|osstr| {
+        path.with_nix_path(|osstr| {
             unsafe {
                 let bytes = osstr.as_bytes();
 
@@ -354,7 +354,7 @@ impl UnixAddr {
 
                 Ok(UnixAddr(ret))
             }
-        }))
+        })
     }
 
     pub fn path(&self) -> &Path {

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -59,9 +59,10 @@ impl fmt::Debug for SFlag {
 
 pub fn mknod<P: ?Sized + NixPath>(path: &P, kind: SFlag, perm: Mode, dev: dev_t) -> Result<()> {
     let res = try!(path.with_nix_path(|osstr| {
-        unsafe {
-            ffi::mknod(osstr.as_ext_str(), kind.bits | perm.bits() as mode_t, dev)
-        }
+        let cstr = try!(osstr.as_ext_str());
+        Ok(unsafe {
+            ffi::mknod(cstr.as_ptr(), kind.bits | perm.bits() as mode_t, dev)
+        })
     }));
     from_ffi(res)
 }
@@ -82,9 +83,10 @@ pub fn umask(mode: Mode) -> Mode {
 pub fn stat<P: ?Sized + NixPath>(path: &P) -> Result<FileStat> {
     let mut dst = unsafe { mem::uninitialized() };
     let res = try!(path.with_nix_path(|osstr| {
-        unsafe {
-            ffi::stat(osstr.as_ext_str(), &mut dst as *mut FileStat)
-        }
+        let cstr = try!(osstr.as_ext_str());
+        Ok(unsafe {
+            ffi::stat(cstr.as_ptr(), &mut dst as *mut FileStat)
+        })
     }));
 
     if res < 0 {
@@ -97,9 +99,10 @@ pub fn stat<P: ?Sized + NixPath>(path: &P) -> Result<FileStat> {
 pub fn lstat<P: ?Sized + NixPath>(path: &P) -> Result<FileStat> {
     let mut dst = unsafe { mem::uninitialized() };
     let res = try!(path.with_nix_path(|osstr| {
-        unsafe {
-            ffi::lstat(osstr.as_ext_str(), &mut dst as *mut FileStat)
-        }
+        let cstr = try!(osstr.as_ext_str());
+        Ok(unsafe {
+            ffi::lstat(cstr.as_ptr(), &mut dst as *mut FileStat)
+        })
     }));
 
     if res < 0 {


### PR DESCRIPTION
As described in #117, the `AsExtStr` trait is defined to return a raw `*const libc::c_char`. Its `impl` for `OsStr` simply borrowed the byte slice from its `OsStr` argument and cast it to a `*const libc::c_char`, which does not construct a proper null-terminated C string.

This changes the `AsExtStr` trait to return a `Result<CString>`, and changes the `impl` for `OsStr` to allocate a new owned `CString` from its `OsStr` argument and return that instead.

Fixes #117
Fixes #120