### PR TITLE
Add sys::socket send and recv

### DIFF
--- a/src/sys/socket/ffi.rs
+++ b/src/sys/socket/ffi.rs
@@ -1,5 +1,5 @@
 use libc::{c_int, c_void, socklen_t};
-pub use libc::{socket, listen, bind, accept, connect, setsockopt, sendto, recvfrom, getsockname, getpeername};
+pub use libc::{socket, listen, bind, accept, connect, setsockopt, sendto, recvfrom, getsockname, getpeername, recv, send};
 
 extern {
     pub fn getsockopt(

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -211,6 +211,26 @@ pub fn connect(fd: Fd, addr: &SockAddr) -> Result<()> {
     from_ffi(res)
 }
 
+/// Receive data from a connection-oriented socket. Returns the number of
+/// bytes read
+///
+/// [Further reading](http://man7.org/linux/man-pages/man2/recv.2.html)
+pub fn recv(sockfd: Fd, buf: &mut [u8], flags: SockMessageFlags) -> Result<usize> {
+    unsafe {
+        let ret = ffi::recv(
+            sockfd,
+            buf.as_ptr() as *mut c_void,
+            buf.len() as size_t,
+            flags);
+
+        if ret < 0 {
+            Err(Error::last())
+        } else {
+            Ok(ret as usize)
+        }
+    }
+}
+
 /// Receive data from a connectionless or connection-oriented socket. Returns
 /// the number of bytes read and the socket address of the sender.
 ///
@@ -245,6 +265,21 @@ pub fn sendto(fd: Fd, buf: &[u8], addr: &SockAddr, flags: SockMessageFlags) -> R
 
     if ret < 0 {
         Err(Error::Sys(Errno::last()))
+    } else {
+        Ok(ret as usize)
+    }
+}
+
+/// Send data to a connection-oriented socket. Returns the number of bytes read 
+///
+/// [Further reading](http://man7.org/linux/man-pages/man2/send.2.html)
+pub fn send(fd: Fd, buf: &[u8], flags: SockMessageFlags) -> Result<usize> {
+    let ret = unsafe {
+        ffi::send(fd, buf.as_ptr() as *const c_void, buf.len() as size_t, flags)
+    };
+
+    if ret < 0 {
+        Err(Error::last())
     } else {
         Ok(ret as usize)
     }


### PR DESCRIPTION
Adds the libc recv and send functions to sys::socket. I wanted this for doing low-level tcp with nix.

Let me know if you need me to improve the patch in some way, or if there's a better way to achieve the same thing. Thanks!