### PR TITLE
added wait system call and unit test

### DIFF
--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -16,7 +16,7 @@ bitflags!(
     }
 );
 
-#[derive(Clone, Copy)]
+#[derive(Eq, PartialEq, Clone, Copy, Debug)]
 pub enum WaitStatus {
     Exited(pid_t),
     StillAlive
@@ -41,4 +41,8 @@ pub fn waitpid(pid: pid_t, options: Option<WaitPidFlag>) -> Result<WaitStatus> {
     } else {
         Ok(Exited(res))
     }
+}
+
+pub fn wait() -> Result<WaitStatus> {
+    waitpid(-1, None)
 }

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -30,6 +30,23 @@ fn test_fork_and_waitpid() {
 }
 
 #[test]
+fn test_wait() {
+    let pid = fork();
+    match pid {
+      Ok(Child) => {} // ignore child here
+      Ok(Parent(child_pid)) => {
+          let wait_status = wait();
+
+          // just assert that (any) one child returns with WaitStatus::Exited
+          assert_eq!(wait_status, Ok(WaitStatus::Exited(child_pid)));
+      },
+      // panic, fork should never fail unless there is a serious problem with the OS
+      Err(_) => panic!("Error: Fork Failed")
+    }
+}
+
+
+#[test]
 fn test_getpid() {
     let pid = getpid();
     let ppid = getppid();


### PR DESCRIPTION
wait in C is equivalent to

 waitpid(-1, &status, 0);

so I just called the waitpid function and did not wrap the C function. 