### PR TITLE
Bump libc dependency up to version 0.1.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude     = [
 eventfd = []
 
 [dependencies]
-libc     = "0.1.4"
+libc     = "0.1.8"
 bitflags = "0.1.1"
 
 [dev-dependencies]


### PR DESCRIPTION
libc::TCP_KEEPIDLE is not defined for linux in libc v0.1.4, so this bump will alleviate that issue.