### PR TITLE
Remove sa_tramp from macos sigaction

### DIFF
--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -266,7 +266,6 @@ pub mod signal {
     #[allow(missing_copy_implementations)]
     pub struct sigaction {
         pub sa_handler: extern fn(libc::c_int),
-        sa_tramp: *mut libc::c_void,
         pub sa_mask: sigset_t,
         pub sa_flags: SockFlag,
     }


### PR DESCRIPTION
Fixes #140  This current implementation follows the struct definition for __sigaction in [include/sys/signal.h](http://www.opensource.apple.com/source/xnu/xnu-2782.1.97/bsd/sys/signal.h).  This changes it to the implementation to ```sigaction``` expected by the sigaction function in include/signal.h.