### PR TITLE
Fix off-by-one error calling Rng::gen_range

### DIFF
--- a/test/sys/test_uio.rs
+++ b/test/sys/test_uio.rs
@@ -18,7 +18,7 @@ fn test_writev() {
     let mut consumed = 0;
     while consumed < to_write.len() {
         let left = to_write.len() - consumed;
-        let slice_len = if left < 64 { left } else { thread_rng().gen_range(64, cmp::min(256, left)) };
+        let slice_len = if left <= 64 { left } else { thread_rng().gen_range(64, cmp::min(256, left)) };
         let b = &to_write[consumed..consumed+slice_len];
         iovecs.push(IoVec::from_slice(b));
         consumed += slice_len;
@@ -57,7 +57,7 @@ fn test_readv() {
     let mut allocated = 0;
     while allocated < to_write.len() {
         let left = to_write.len() - allocated;
-        let vec_len = if left < 64 { left } else { thread_rng().gen_range(64, cmp::min(256, left)) };
+        let vec_len = if left <= 64 { left } else { thread_rng().gen_range(64, cmp::min(256, left)) };
         let v: Vec<u8> = iter::repeat(0u8).take(vec_len).collect();
         storage.push(v);
         allocated += vec_len;


### PR DESCRIPTION
Fix the boundary condition so that we never call

    Rng::gen_range(64, 64).

Helps #144