### PR TITLE
remove unneeded mut.

### DIFF
--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -224,10 +224,9 @@ pub fn write(fd: RawFd, buf: &[u8]) -> Result<usize> {
 
 pub fn pipe() -> Result<(RawFd, RawFd)> {
     unsafe {
-        let mut res;
         let mut fds: [c_int; 2] = mem::uninitialized();
 
-        res = ffi::pipe(fds.as_mut_ptr());
+        let res = ffi::pipe(fds.as_mut_ptr());
 
         if res < 0 {
             return Err(Error::Sys(Errno::last()));
@@ -239,10 +238,9 @@ pub fn pipe() -> Result<(RawFd, RawFd)> {
 
 pub fn pipe2(flags: OFlag) -> Result<(RawFd, RawFd)> {
     unsafe {
-        let mut res;
         let mut fds: [c_int; 2] = mem::uninitialized();
 
-        res = ffi::pipe(fds.as_mut_ptr());
+        let res = ffi::pipe(fds.as_mut_ptr());
 
         if res < 0 {
             return Err(Error::Sys(Errno::last()));


### PR DESCRIPTION
Hi,

I think this diff avoids an unneeded mut.

nightly will comment this with:

---
src/unistd.rs:241:13: 241:20 error: variable does not need to be mutable, #[deny(unused_mut)] on by default
src/unistd.rs:241         let mut res;
---