### PR TITLE
Add status to WaitStatus

### DIFF
--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -2,6 +2,8 @@ use libc::{pid_t, c_int};
 use errno::Errno;
 use {Error, Result};
 
+use sys::signal;
+
 mod ffi {
     use libc::{pid_t, c_int};
 
@@ -18,8 +20,153 @@ bitflags!(
 
 #[derive(Eq, PartialEq, Clone, Copy, Debug)]
 pub enum WaitStatus {
-    Exited(pid_t),
+    Exited(pid_t, i8),
+    Signaled(pid_t, signal::SigNum, bool),
+    Stopped(pid_t, signal::SigNum),
+    Continued(pid_t),
     StillAlive
+}
+
+#[cfg(any(target_os = "linux",
+          target_os = "android"))]
+mod status {
+    use sys::signal;
+
+    pub fn exited(status: i32) -> bool {
+        (status & 0x7F) == 0
+    }
+
+    pub fn exit_status(status: i32) -> i8 {
+        ((status & 0xFF00) >> 8) as i8
+    }
+
+    pub fn signaled(status: i32) -> bool {
+        ((((status & 0x7f) + 1) as i8) >> 1) > 0
+    }
+
+    pub fn term_signal(status: i32) -> signal::SigNum {
+        (status & 0x7f) as signal::SigNum
+    }
+
+    pub fn dumped_core(status: i32) -> bool {
+        (status & 0x80) != 0
+    }
+
+    pub fn stopped(status: i32) -> bool {
+        (status & 0xff) == 0x7f
+    }
+
+    pub fn stop_signal(status: i32) -> signal::SigNum {
+        ((status & 0xFF00) >> 8) as signal::SigNum
+    }
+
+    pub fn continued(status: i32) -> bool {
+        status == 0xFFFF
+    }
+}
+
+#[cfg(any(target_os = "macos",
+          target_os = "ios"))]
+mod status {
+    use sys::signal;
+
+    const WCOREFLAG: i32 = 0x80;
+    const WSTOPPED: i32 = 0x7f;
+
+    fn wstatus(status: i32) -> i32 {
+        status & 0x7F
+    }
+
+    pub fn exit_status(status: i32) -> i8 {
+        ((status >> 8) & 0xFF) as i8
+    }
+
+    pub fn stop_signal(status: i32) -> signal::SigNum {
+        (status >> 8) as signal::SigNum
+    }
+
+    pub fn continued(status: i32) -> bool {
+        wstatus(status) == WSTOPPED && stop_signal(status) == 0x13
+    }
+
+    pub fn stopped(status: i32) -> bool {
+        wstatus(status) == WSTOPPED && stop_signal(status) != 0x13
+    }
+
+    pub fn exited(status: i32) -> bool {
+        wstatus(status) == 0
+    }
+
+    pub fn signaled(status: i32) -> bool {
+        wstatus(status) != WSTOPPED && wstatus(status) != 0
+    }
+
+    pub fn term_signal(status: i32) -> signal::SigNum {
+        wstatus(status) as signal::SigNum
+    }
+
+    pub fn dumped_core(status: i32) -> bool {
+        (status & WCOREFLAG) != 0
+    }
+}
+
+#[cfg(any(target_os = "freebsd",
+          target_os = "openbsd",
+          target_os = "dragonfly"))]
+mod status {
+    use sys::signal;
+
+    const WCOREFLAG: i32 = 0x80;
+    const WSTOPPED: i32 = 0x7f;
+
+    fn wstatus(status: i32) -> i32 {
+        status & 0x7F
+    }
+
+    pub fn stopped(status: i32) -> bool {
+        wstatus(status) == WSTOPPED
+    }
+
+    pub fn stop_signal(status: i32) -> signal::SigNum {
+        (status >> 8) as signal::SigNum
+    }
+
+    pub fn signaled(status: i32) -> bool {
+        wstatus(status) != WSTOPPED && wstatus(status) != 0 && status != 0x13
+    }
+
+    pub fn term_signal(status: i32) -> signal::SigNum {
+        wstatus(status) as signal::SigNum
+    }
+
+    pub fn exited(status: i32) -> bool {
+        wstatus(status) == 0
+    }
+
+    pub fn exit_status(status: i32) -> i8 {
+        (status >> 8) as i8
+    }
+
+    pub fn continued(status: i32) -> bool {
+        status == 0x13
+    }
+
+    pub fn dumped_core(status: i32) -> bool {
+        (status & WCOREFLAG) != 0
+    }
+}
+
+fn decode(pid : pid_t, status: i32) -> WaitStatus {
+    if status::exited(status) {
+        WaitStatus::Exited(pid, status::exit_status(status))
+    } else if status::signaled(status) {
+        WaitStatus::Signaled(pid, status::term_signal(status), status::dumped_core(status))
+    } else if status::stopped(status) {
+        WaitStatus::Stopped(pid, status::stop_signal(status))
+    } else {
+        assert!(status::continued(status));
+        WaitStatus::Continued(pid)
+    }
 }
 
 pub fn waitpid(pid: pid_t, options: Option<WaitPidFlag>) -> Result<WaitStatus> {
@@ -39,7 +186,7 @@ pub fn waitpid(pid: pid_t, options: Option<WaitPidFlag>) -> Result<WaitStatus> {
     } else if res == 0 {
         Ok(StillAlive)
     } else {
-        Ok(Exited(res))
+        Ok(decode(res, status))
     }
 }
 

--- a/test/sys/mod.rs
+++ b/test/sys/mod.rs
@@ -2,3 +2,4 @@ mod test_socket;
 mod test_termios;
 mod test_uio;
 mod test_ioctl;
+mod test_wait;

--- a/test/sys/test_wait.rs
+++ b/test/sys/test_wait.rs
@@ -1,0 +1,30 @@
+use nix::unistd::*;
+use nix::unistd::Fork::*;
+use nix::sys::signal::*;
+use nix::sys::wait::*;
+use libc::funcs::c95::stdlib::exit;
+
+#[test]
+fn test_wait_signal() {
+    match fork() {
+      Ok(Child) => loop { /* Wait for signal */ },
+      Ok(Parent(child_pid)) => {
+          kill(child_pid, SIGKILL).ok().expect("Error: Kill Failed");
+          assert_eq!(waitpid(child_pid, None), Ok(WaitStatus::Signaled(child_pid, SIGKILL, false)));
+      },
+      // panic, fork should never fail unless there is a serious problem with the OS
+      Err(_) => panic!("Error: Fork Failed")
+    }
+}
+
+#[test]
+fn test_wait_exit() {
+    match fork() {
+      Ok(Child) => unsafe { exit(12); },
+      Ok(Parent(child_pid)) => {
+          assert_eq!(waitpid(child_pid, None), Ok(WaitStatus::Exited(child_pid, 12)));
+      },
+      // panic, fork should never fail unless there is a serious problem with the OS
+      Err(_) => panic!("Error: Fork Failed")
+    }
+}

--- a/test/test_unistd.rs
+++ b/test/test_unistd.rs
@@ -14,10 +14,10 @@ fn test_fork_and_waitpid() {
           let wait_status = waitpid(child_pid, None);
           match wait_status {
               // assert that waitpid returned correct status and the pid is the one of the child
-              Ok(WaitStatus::Exited(pid_t)) =>  assert!(pid_t == child_pid),
+              Ok(WaitStatus::Exited(pid_t, _)) =>  assert!(pid_t == child_pid),
 
               // panic, must never happen
-              Ok(WaitStatus::StillAlive) => panic!("Child still alive, should never happen"),
+              Ok(_) => panic!("Child still alive, should never happen"),
 
               // panic, waitpid should never fail
               Err(_) => panic!("Error: waitpid Failed")
@@ -38,7 +38,7 @@ fn test_wait() {
           let wait_status = wait();
 
           // just assert that (any) one child returns with WaitStatus::Exited
-          assert_eq!(wait_status, Ok(WaitStatus::Exited(child_pid)));
+          assert_eq!(wait_status, Ok(WaitStatus::Exited(child_pid, 0)));
       },
       // panic, fork should never fail unless there is a serious problem with the OS
       Err(_) => panic!("Error: Fork Failed")


### PR DESCRIPTION
* Extend the enums in WaitStatus to include all process states (signaled,
  stopped, exited, continued).
* Decode status from waitpid
* Return appropate WaitStatus
* Update tests to use the new WaitStatus
* Add new tests for specific status values