### PR TITLE
Fix unit tests as blank files can still have blocks

### DIFF
--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -23,7 +23,7 @@ fn assert_stat_results(stat_result: Result<FileStat>) {
             assert!(stats.st_rdev == 0);    // no special device
             assert!(stats.st_size == 0);    // size is 0 because we did not write anything to the file
             assert!(stats.st_blksize > 0);  // must be positive integer, exact number machine dependent
-            assert!(stats.st_blocks == 0);  // no blocks allocated because file size is 0
+            assert!(stats.st_blocks >= 16);  // Up to 16 blocks can be allocated for a blank file
         }
         Err(_) => panic!("stat call failed") // if stats system call fails, something is seriously wrong on that machine
     }


### PR DESCRIPTION
$ stat baz
  File: ‘baz’
  Size: 0         	Blocks: 16         IO Block: 4096   regular empty file
Device: 26h/38d	Inode: 6835152     Links: 1
Access: (0664/-rw-rw-r--)  Uid: ( 1000/ posix4e)   Gid: ( 1000/ posix4e)
Access: 2015-07-10 11:11:21.846851777 -0700
Modify: 2015-07-10 11:11:21.846851777 -0700
Change: 2015-07-10 11:11:21.846851777 -0700
 Birth: -