### PR TITLE
added mq_getattr for the mqueue modul

### DIFF
--- a/src/mqueue.rs
+++ b/src/mqueue.rs
@@ -33,23 +33,25 @@ mod consts {
 }
 
 mod ffi {
-    use libc::{c_char, size_t, ssize_t, c_uint, c_int, mode_t};
+    use libc::{c_char, size_t, ssize_t, c_uint, c_int};
     use super::MQd;
     use super::MqAttr;
 
-    extern {
-        pub fn mq_open(name: *const c_char, oflag: c_int, mode: mode_t, attr: *const MqAttr) -> MQd;
+    extern "C" {
+        pub fn mq_open(name: *const c_char, oflag: c_int, ...) -> MQd;
 
-        pub fn mq_close (mqdes: MQd) -> c_int;
+        pub fn mq_close (mqd: MQd) -> c_int;
 
-        pub fn mq_receive (mqdes: MQd, msg_ptr: *const c_char, msg_len: size_t, msq_prio: *const c_uint) -> ssize_t;
+        pub fn mq_receive (mqd: MQd, msg_ptr: *const c_char, msg_len: size_t, msq_prio: *const c_uint) -> ssize_t;
 
-        pub fn mq_send (mqdes: MQd, msg_ptr: *const c_char, msg_len: size_t, msq_prio: c_uint) -> c_int;
+        pub fn mq_send (mqd: MQd, msg_ptr: *const c_char, msg_len: size_t, msq_prio: c_uint) -> c_int;
+
+        pub fn mq_getattr(mqd: MQd, attr: *mut MqAttr) -> c_int;
     }
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct MqAttr {
     pub mq_flags: c_long,
     pub mq_maxmsg: c_long,
@@ -94,4 +96,13 @@ pub fn mq_send(mqdes: MQd, message: &CString, msq_prio: u32) -> Result<usize> {
     }
 
     Ok(res as usize)
+}
+
+pub fn mq_getattr(mqd: MQd) -> Result<MqAttr> {
+    let mut attr = Box::new(MqAttr { mq_flags: 0, mq_maxmsg: 0, mq_msgsize: 0, mq_curmsgs: 0 });
+    let res = unsafe { ffi::mq_getattr(mqd, &mut *attr) };
+    if res < 0 {
+        return Err(Error::Sys(Errno::last()));
+    }
+    Ok(*attr)
 }

--- a/test/test_mq.rs
+++ b/test/test_mq.rs
@@ -1,4 +1,4 @@
-use nix::mqueue::{mq_open, mq_close, mq_send, mq_receive};
+use nix::mqueue::{mq_open, mq_close, mq_send, mq_receive, mq_getattr};
 use nix::mqueue::{O_CREAT, O_WRONLY, O_RDONLY};
 use nix::mqueue::MqAttr;
 use nix::sys::stat::{S_IWUSR, S_IRUSR, S_IRGRP, S_IROTH};
@@ -14,18 +14,13 @@ use nix::sys::wait::*;
 
 #[test]
 fn mq_send_and_receive() {
-
     const MSG_SIZE: c_long =  32;
-
     let attr =  MqAttr { mq_flags: 0, mq_maxmsg: 10, mq_msgsize: MSG_SIZE, mq_curmsgs: 0 };
     let mq_name_in_parent = &CString::new(b"/a_nix_test_queue".as_ref()).unwrap();
     let mqd_in_parent = mq_open(mq_name_in_parent, O_CREAT | O_WRONLY, S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH, &attr).unwrap();
     let msg_to_send = &CString::new("msg_1").unwrap();
-
     mq_send(mqd_in_parent, msg_to_send, 1).unwrap();
-
     let (reader, writer) = pipe().unwrap();
-
     let pid = fork();
     match pid {
         Ok(Child) => {
@@ -50,4 +45,16 @@ fn mq_send_and_receive() {
       // panic, fork should never fail unless there is a serious problem with the OS
       Err(_) => panic!("Error: Fork Failed")
     }
+}
+
+
+#[test]
+fn mq_get_attr() {
+    const MSG_SIZE: c_long =  32;
+    let initial_attr =  MqAttr { mq_flags: 0, mq_maxmsg: 10, mq_msgsize: MSG_SIZE, mq_curmsgs: 0 };
+    let mq_name = &CString::new("/attr_test_get_attr".as_bytes().as_ref()).unwrap();
+    let mqd = mq_open(mq_name, O_CREAT | O_WRONLY, S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH, &initial_attr).unwrap();
+    let read_attr = mq_getattr(mqd);
+    assert!(read_attr.unwrap() == initial_attr);
+    mq_close(mqd).unwrap();
 }


### PR DESCRIPTION
This needs a careful review. It took me a while to write this without the test crashed with Signal 4.

Please have a look at these 2 lines in particular (line 102/103)

let mut attr = Box::new(MqAttr { mq_flags: 0, mq_maxmsg: 0, mq_msgsize: 0, mq_curmsgs: 0 });
let res = unsafe { ffi::mq_getattr(mqd, &mut *attr) };

Is this correct? I read on the docs that Box::new should be used. In the C code a pointer to the struct is passed. I first had is stack allocated but that lead to all the crashes. See the issue ticked I opened and later closed for more information. 

https://github.com/carllerche/nix-rust/issues/142

If this works, Rust users won't have to deal with this low level C stuff :-)