### PR TITLE
Fix deprecated item

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ exclude     = [
 
 eventfd = []
 execvpe = []
+1_0 = []
 
 [dependencies]
 libc     = "0.1.8"

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::os::unix::fs;
 use std::str;
 
 use libc::consts::os::posix88;
@@ -73,7 +73,7 @@ fn test_stat_fstat_lstat() {
     let linkname = b"target/barlink".as_ref();
 
     open(filename, O_CREAT, S_IWUSR | S_IRUSR).unwrap();  // create empty file
-    fs::soft_link("bar.txt", str::from_utf8(linkname).unwrap()).unwrap();
+    fs::symlink("bar.txt", str::from_utf8(linkname).unwrap()).unwrap();
     let fd = open(linkname, O_RDONLY, S_IRUSR).unwrap();
 
     // should be the same result as calling stat,

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -1,4 +1,9 @@
-use std::os::unix::fs;
+#[cfg(feature = "1_0")]
+use std::fs::soft_link as symlink;
+
+#[cfg(not(feature = "1_0"))]
+use std::os::unix::fs::symlink;
+
 use std::str;
 
 use libc::consts::os::posix88;
@@ -73,7 +78,7 @@ fn test_stat_fstat_lstat() {
     let linkname = b"target/barlink".as_ref();
 
     open(filename, O_CREAT, S_IWUSR | S_IRUSR).unwrap();  // create empty file
-    fs::symlink("bar.txt", str::from_utf8(linkname).unwrap()).unwrap();
+    symlink("bar.txt", str::from_utf8(linkname).unwrap()).unwrap();
     let fd = open(linkname, O_RDONLY, S_IRUSR).unwrap();
 
     // should be the same result as calling stat,


### PR DESCRIPTION
warning: use of deprecated item: replaced with std::os::unix::fs::symlink and std::os::windows::fs::{symlink_file, symlink_dir}, #[warn(deprecated)] on by default