### PR TITLE
Make it compatible for Android.

### DIFF
--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -10,28 +10,34 @@ pub use self::ffi::consts::FlushArg::*;
 pub use self::ffi::consts::FlowArg::*;
 
 mod ffi {
-    use libc::c_int;
-
     pub use self::consts::*;
 
-    // `Termios` contains bitflags which are not considered
-    // `foreign-function-safe` by the compiler.
-    #[allow(improper_ctypes)]
     #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "linux"))]
-    extern {
-        pub fn cfgetispeed(termios: *const Termios) -> speed_t;
-        pub fn cfgetospeed(termios: *const Termios) -> speed_t;
-        pub fn cfsetispeed(termios: *mut Termios, speed: speed_t) -> c_int;
-        pub fn cfsetospeed(termios: *mut Termios, speed: speed_t) -> c_int;
-        pub fn tcgetattr(fd: c_int, termios: *mut Termios) -> c_int;
-        pub fn tcsetattr(fd: c_int,
-                         optional_actions: c_int,
-                         termios: *const Termios) -> c_int;
-        pub fn tcdrain(fd: c_int) -> c_int;
-        pub fn tcflow(fd: c_int, action: c_int) -> c_int;
-        pub fn tcflush(fd: c_int, action: c_int) -> c_int;
-        pub fn tcsendbreak(fd: c_int, duration: c_int) -> c_int;
+    mod non_android {
+        use super::consts::*;
+        use libc::c_int;
+
+        // `Termios` contains bitflags which are not considered
+        // `foreign-function-safe` by the compiler.
+        #[allow(improper_ctypes)]
+        extern {
+            pub fn cfgetispeed(termios: *const Termios) -> speed_t;
+            pub fn cfgetospeed(termios: *const Termios) -> speed_t;
+            pub fn cfsetispeed(termios: *mut Termios, speed: speed_t) -> c_int;
+            pub fn cfsetospeed(termios: *mut Termios, speed: speed_t) -> c_int;
+            pub fn tcgetattr(fd: c_int, termios: *mut Termios) -> c_int;
+            pub fn tcsetattr(fd: c_int,
+                             optional_actions: c_int,
+                             termios: *const Termios) -> c_int;
+            pub fn tcdrain(fd: c_int) -> c_int;
+            pub fn tcflow(fd: c_int, action: c_int) -> c_int;
+            pub fn tcflush(fd: c_int, action: c_int) -> c_int;
+            pub fn tcsendbreak(fd: c_int, duration: c_int) -> c_int;
+        }
     }
+
+    #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "linux"))]
+    pub use self::non_android::*;
 
     // On Android before 5.0, Bionic directly inline these to ioctl() calls.
     #[inline]

--- a/src/sys/uio.rs
+++ b/src/sys/uio.rs
@@ -23,13 +23,13 @@ mod ffi {
 
         // vectorized write at a specified offset
         // doc: http://man7.org/linux/man-pages/man2/pwritev.2.html
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(target_os = "linux")]
         pub fn pwritev(fd: RawFd, iov: *const IoVec<&[u8]>, iovcnt: c_int,
                        offset: off_t) -> ssize_t;
 
         // vectorized read at a specified offset
         // doc: http://man7.org/linux/man-pages/man2/preadv.2.html
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(target_os = "linux")]
         pub fn preadv(fd: RawFd, iov: *const IoVec<&mut [u8]>, iovcnt: c_int,
                       offset: off_t) -> ssize_t;
 
@@ -64,7 +64,7 @@ pub fn readv(fd: RawFd, iov: &mut [IoVec<&mut [u8]>]) -> Result<usize> {
     return Ok(res as usize)
 }
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(target_os = "linux")]
 pub fn pwritev(fd: RawFd, iov: &[IoVec<&[u8]>],
                offset: off_t) -> Result<usize> {
     let res = unsafe {
@@ -77,7 +77,7 @@ pub fn pwritev(fd: RawFd, iov: &[IoVec<&[u8]>],
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(target_os = "linux")]
 pub fn preadv(fd: RawFd, iov: &mut [IoVec<&mut [u8]>],
               offset: off_t) -> Result<usize> {
     let res = unsafe {

--- a/test/sys/test_uio.rs
+++ b/test/sys/test_uio.rs
@@ -130,7 +130,7 @@ fn test_pread() {
 }
 
 #[test]
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(target_os = "linux")]
 fn test_pwritev() {
     use std::io::Read;
 
@@ -160,7 +160,7 @@ fn test_pwritev() {
 }
 
 #[test]
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(target_os = "linux")]
 fn test_preadv() {
     use std::io::Write;
 

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -38,11 +38,11 @@ fn assert_lstat_results(stat_result: Result<FileStat>) {
             assert!(stats.st_ino > 0);      // inode is positive integer, exact number machine dependent
             assert!(stats.st_mode > 0);     // must be positive integer
 
-            // st_mode is c_uint (u32) on Android and mode_t (u32) on all other
-            // *nix OSs; S_IFMT is mode_t (u16 on Android, u32 on all other
-            // *nix OSs). Therefore casting mode_t to u32 should be safe..
-            assert!(stats.st_mode & (posix88::S_IFMT as u32)
-                    == posix88::S_IFLNK as u32); // should be a link
+            // st_mode is c_uint (u32 on Android) while S_IFMT is mode_t
+            // (u16 on Android), and that will be a compile error.
+            // On other platforms they are the same (either both are u16 or u32).
+            assert!((stats.st_mode as usize) & (posix88::S_IFMT as usize)
+                    == posix88::S_IFLNK as usize); // should be a link
             assert!(stats.st_nlink == 1);   // there links created, must be 1
             // uid could be 0 for the `root` user. This quite possible when
             // the tests are being run on a rooted Android device.

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -18,8 +18,10 @@ fn assert_stat_results(stat_result: Result<FileStat>) {
             assert!(stats.st_ino > 0);      // inode is positive integer, exact number machine dependent
             assert!(stats.st_mode > 0);     // must be positive integer
             assert!(stats.st_nlink == 1);   // there links created, must be 1
-            assert!(stats.st_uid > 0);      // must be positive integer
-            assert!(stats.st_gid > 0);      // must be positive integer
+            // uid could be 0 for the `root` user. This quite possible when
+            // the tests are being run on a rooted Android device.
+            assert!(stats.st_uid >= 0);      // must be positive integer
+            assert!(stats.st_gid >= 0);      // must be positive integer
             assert!(stats.st_rdev == 0);    // no special device
             assert!(stats.st_size == 0);    // size is 0 because we did not write anything to the file
             assert!(stats.st_blksize > 0);  // must be positive integer, exact number machine dependent
@@ -35,17 +37,24 @@ fn assert_lstat_results(stat_result: Result<FileStat>) {
             assert!(stats.st_dev > 0);      // must be positive integer, exact number machine dependent
             assert!(stats.st_ino > 0);      // inode is positive integer, exact number machine dependent
             assert!(stats.st_mode > 0);     // must be positive integer
-            assert!(stats.st_mode & posix88::S_IFMT
-                    == posix88::S_IFLNK); // should be a link
+
+            // st_mode is c_uint (u32) on Android and mode_t (u32) on all other
+            // *nix OSs; S_IFMT is mode_t (u16 on Android, u32 on all other
+            // *nix OSs). Therefore casting mode_t to u32 should be safe..
+            assert!(stats.st_mode & (posix88::S_IFMT as u32)
+                    == posix88::S_IFLNK as u32); // should be a link
             assert!(stats.st_nlink == 1);   // there links created, must be 1
-            assert!(stats.st_uid > 0);      // must be positive integer
-            assert!(stats.st_gid > 0);      // must be positive integer
+            // uid could be 0 for the `root` user. This quite possible when
+            // the tests are being run on a rooted Android device.
+            assert!(stats.st_uid >= 0);      // must be positive integer
+            assert!(stats.st_gid >= 0);      // must be positive integer
             assert!(stats.st_rdev == 0);    // no special device
             assert!(stats.st_size > 0);    // size is > 0 because it points to another file
             assert!(stats.st_blksize > 0);  // must be positive integer, exact number machine dependent
 
             // st_blocks depends on whether the machine's file system uses fast
             // or slow symlinks, so just make sure it's not negative
+            // (Android's st_blocks is ulonglong which is always non-negative.)
             assert!(stats.st_blocks >= 0);
         }
         Err(_) => panic!("stat call failed") // if stats system call fails, something is seriously wrong on that machine


### PR DESCRIPTION
* Fixed an unused_import error in `termios.rs` for Android.
* Fixed undefined references to `preadv` and `pwritev` for Android -
  At least they don't exist from API level 3 to 21.
* Fixed the uid > 0 and gid > 0 checks in `stat`'s tests - Running the
  tests by root is possible, especially when running on a rooted Android
  device.

Those changes made rust-nix buildable (again) on Android. All the tests
passed on my rooted Android 4.2 as well.