### PR TITLE
Add flock(2) support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ eventfd = []
 execvpe = []
 
 [dependencies]
-libc     = "0.1.8"
+libc     = "0.1.10"
 bitflags = "0.1.1"
 
 [dev-dependencies]


### PR DESCRIPTION
Adds basic support for calling flock().

I could see going further and adding the equivalent of std::sync::Mutex's MutexGuard for automatic unlocking at the end of scope. Not sure if that would fit with the rather low-level nature of Nix, though.