### PR TITLE
Fix the struct packing of EpollEvent

### DIFF
--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -50,19 +50,26 @@ pub struct EpollEvent {
     pub data: u64
 }
 
-#[cfg(not(target_arch = "x86_64"))]
-#[test]
-fn test_epoll_event_size() {
-    use std::mem::size_of;
-    assert_eq!(size_of::<EpollEvent>(), 16);
-}
-
 #[cfg(target_arch = "x86_64")]
 #[derive(Clone, Copy)]
 #[repr(C, packed)]
 pub struct EpollEvent {
     pub events: EpollEventKind,
     pub data: u64
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[test]
+fn test_epoll_event_size() {
+    use std::mem::size_of;
+    assert_eq!(size_of::<EpollEvent>(), 12);
+}
+
+#[cfg(target_arch = "arm")]
+#[test]
+fn test_epoll_event_size() {
+    use std::mem::size_of;
+    assert_eq!(size_of::<EpollEvent>(), 16);
 }
 
 #[inline]

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -42,7 +42,7 @@ pub enum EpollOp {
     EpollCtlMod = 3
 }
 
-#[cfg(all(target_os = "android", not(target_arch = "x86_64")))]
+#[cfg(not(target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct EpollEvent {
@@ -50,14 +50,14 @@ pub struct EpollEvent {
     pub data: u64
 }
 
-#[cfg(all(target_os = "android", not(target_arch = "x86_64")))]
+#[cfg(not(target_arch = "x86_64"))]
 #[test]
 fn test_epoll_event_size() {
     use std::mem::size_of;
     assert_eq!(size_of::<EpollEvent>(), 16);
 }
 
-#[cfg(any(not(target_os = "android"), target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 #[derive(Clone, Copy)]
 #[repr(C, packed)]
 pub struct EpollEvent {


### PR DESCRIPTION
According to the [Linux source code](https://github.com/torvalds/linux/blob/95803812cfb3ece8ee1bb3747611ead48300fca2/include/uapi/linux/eventpoll.h#L47-L62), EpollEvent should only use packing on x86_64.

Fixes #181.