### PR TITLE
added support and tests for mq_setattr

### DIFF
--- a/src/mqueue.rs
+++ b/src/mqueue.rs
@@ -49,6 +49,8 @@ mod ffi {
         pub fn mq_send (mqd: MQd, msg_ptr: *const c_char, msg_len: size_t, msq_prio: c_uint) -> c_int;
 
         pub fn mq_getattr(mqd: MQd, attr: *mut MqAttr) -> c_int;
+
+        pub fn mq_setattr(mqd: MQd, newattr: *const MqAttr, oldattr: *mut MqAttr) -> c_int;
     }
 }
 
@@ -116,6 +118,16 @@ pub fn mq_send(mqdes: MQd, message: &CString, msq_prio: u32) -> Result<usize> {
 pub fn mq_getattr(mqd: MQd) -> Result<MqAttr> {
     let mut attr = MqAttr::new(0, 0, 0, 0);
     let res = unsafe { ffi::mq_getattr(mqd, &mut attr) };
+    if res < 0 {
+        return Err(Error::Sys(Errno::last()));
+    }
+    Ok(attr)
+}
+
+
+pub fn mq_setattr(mqd: MQd, newattr: &MqAttr) -> Result<MqAttr> {
+    let mut attr = MqAttr::new(0, 0, 0, 0);
+    let res = unsafe { ffi::mq_setattr(mqd, newattr as *const MqAttr, &mut attr) };
     if res < 0 {
         return Err(Error::Sys(Errno::last()));
     }

--- a/test/test_mq.rs
+++ b/test/test_mq.rs
@@ -81,7 +81,7 @@ fn test_mq_set_attr() {
     // O_NONBLOCK can be set (see tests below)
     assert!(new_attr_get.unwrap() != new_attr);
 
-    let new_attr_non_blocking =  MqAttr::new(O_NONBLOCK.bits() as i64, 10, MSG_SIZE, 0);
+    let new_attr_non_blocking =  MqAttr::new(O_NONBLOCK.bits() as c_long, 10, MSG_SIZE, 0);
     mq_setattr(mqd, &new_attr_non_blocking).unwrap();
     let new_attr_get = mq_getattr(mqd);
 


### PR DESCRIPTION
now finally the PR for mq_setattr.

On Linux only O_NONBLOCK can be set.

If the PR is ok I'll add convenience methods for setting and removing that flag to make it clearer and easier.