### PR TITLE
Ioctl cleanup

### DIFF
--- a/src/sys/ioctl/mod.rs
+++ b/src/sys/ioctl/mod.rs
@@ -30,13 +30,61 @@
 //! What does this module support?
 //! ===============================
 //!
-//! This library provides the `ioctl!` macro, for binding `ioctl`s. It also tries
-//! to bind every `ioctl` supported by the system with said macro, but
-//! some `ioctl`s requires some amount of manual work (usually by
-//! providing `struct` declaration) that this library does not support yet.
+//! This library provides the `ioctl!` macro, for binding `ioctl`s.
+//! Here's a few examples of how that can work for SPI under Linux
+//! from [rust-spidev](https://github.com/posborne/rust-spidev).
 //!
-//! Additionally, in `etc`, there are scripts for scraping system headers for
-//! `ioctl` definitions, and generating calls to `ioctl!` corresponding to them.
+//! ```
+//! #[macro_use] extern crate nix;
+//!
+//! #[allow(non_camel_case_types)]
+//! pub struct spi_ioc_transfer {
+//!     pub tx_buf: u64,
+//!     pub rx_buf: u64,
+//!     pub len: u32,
+//!
+//!     // optional overrides
+//!     pub speed_hz: u32,
+//!     pub delay_usecs: u16,
+//!     pub bits_per_word: u8,
+//!     pub cs_change: u8,
+//!     pub pad: u32,
+//! }
+//!
+//! mod ioctl {
+//!     use super::*;
+//!
+//!     const SPI_IOC_MAGIC: u8 = 'k' as u8;
+//!     const SPI_IOC_NR_TRANSFER: u8 = 0;
+//!     const SPI_IOC_NR_MODE: u8 = 1;
+//!     const SPI_IOC_NR_LSB_FIRST: u8 = 2;
+//!     const SPI_IOC_NR_BITS_PER_WORD: u8 = 3;
+//!     const SPI_IOC_NR_MAX_SPEED_HZ: u8 = 4;
+//!     const SPI_IOC_NR_MODE32: u8 = 5;
+//!
+//!     ioctl!(read  get_mode_u8 with SPI_IOC_MAGIC, SPI_IOC_NR_MODE; u8);
+//!     ioctl!(read  get_mode_u32 with SPI_IOC_MAGIC, SPI_IOC_NR_MODE; u32);
+//!     ioctl!(write set_mode_u8 with SPI_IOC_MAGIC, SPI_IOC_NR_MODE; u8);
+//!     ioctl!(write set_mode_u32 with SPI_IOC_MAGIC, SPI_IOC_NR_MODE32; u32);
+//!     ioctl!(read  get_lsb_first with SPI_IOC_MAGIC, SPI_IOC_NR_LSB_FIRST; u8);
+//!     ioctl!(write set_lsb_first with SPI_IOC_MAGIC, SPI_IOC_NR_LSB_FIRST; u8);
+//!     ioctl!(read  get_bits_per_word with SPI_IOC_MAGIC, SPI_IOC_NR_BITS_PER_WORD; u8);
+//!     ioctl!(write set_bits_per_word with SPI_IOC_MAGIC, SPI_IOC_NR_BITS_PER_WORD; u8);
+//!     ioctl!(read  get_max_speed_hz with SPI_IOC_MAGIC, SPI_IOC_NR_MAX_SPEED_HZ; u32);
+//!     ioctl!(write set_max_speed_hz with SPI_IOC_MAGIC, SPI_IOC_NR_MAX_SPEED_HZ; u32);
+//!     ioctl!(write spidev_transfer with SPI_IOC_MAGIC, SPI_IOC_NR_TRANSFER; spi_ioc_transfer);
+//!     ioctl!(write buf spidev_transfer_buf with SPI_IOC_MAGIC, SPI_IOC_NR_TRANSFER; spi_ioc_transfer);
+//! }
+//!
+//! // doctest workaround
+//! fn main() {}
+//! ```
+//!
+//! Spidev uses the `_IOC` macros that are encouraged (as far as
+//! `ioctl` can be encouraged at all) for newer drivers.  Many
+//! drivers, however, just use magic numbers with no attached
+//! semantics.  For those, the `ioctl!(bad ...)` variant should be
+//! used (the "bad" terminology is from the Linux kernel).
 //!
 //! How do I get the magic numbers?
 //! ===============================
@@ -50,28 +98,6 @@
 //! Most `ioctl`s have no or little documentation. You'll need to scrounge through
 //! the source to figure out what they do and how they should be used.
 //!
-//! # Interface Overview
-//!
-//! This ioctl module seeks to tame the ioctl beast by providing a set of safer (although not safe)
-//! functions implementing the most common ioctl access patterns.
-//!
-//! The most common access patterns for ioctls are as follows:
-//!
-//! 1. `read`: A pointer is provided to the kernel which is populated
-//!    with a value containing the "result" of the operation.  The
-//!    result may be an integer or structure.  The kernel may also
-//!    read values from the provided pointer (usually a structure).
-//! 2. `write`: A pointer is provided to the kernel containing values
-//!    that the kernel will read in order to perform the operation.
-//! 3. `execute`: The operation is passed to the kernel but no
-//!    additional pointer is passed.  The operation is enough
-//!    and it either succeeds or results in an error.
-//!
-//! Where appropriate, versions of these interface function are provided
-//! taking either refernces or pointers.  The pointer versions are
-//! necessary for cases (notably slices) where a reference cannot
-//! be generically cast to a pointer.
-
 #[cfg(any(target_os = "linux", target_os = "android"))]
 #[path = "platform/linux.rs"]
 #[macro_use]

--- a/src/sys/ioctl/mod.rs
+++ b/src/sys/ioctl/mod.rs
@@ -51,6 +51,7 @@
 //!     pub pad: u32,
 //! }
 //!
+//! #[cfg(linux)]
 //! mod ioctl {
 //!     use super::*;
 //!

--- a/src/sys/ioctl/platform/linux.rs
+++ b/src/sys/ioctl/platform/linux.rs
@@ -1,59 +1,46 @@
-#[doc(hidden)]
 pub const NRBITS: u32 = 8;
-#[doc(hidden)]
 pub const TYPEBITS: u32 = 8;
 
 #[cfg(any(target_arch = "mips", target_arch = "powerpc"))]
 mod consts {
-    #[doc(hidden)]
     pub const NONE: u8 = 1;
-    #[doc(hidden)]
     pub const READ: u8 = 2;
-    #[doc(hidden)]
     pub const WRITE: u8 = 4;
-    #[doc(hidden)]
     pub const SIZEBITS: u8 = 13;
-    #[doc(hidden)]
     pub const DIRBITS: u8 = 3;
 }
 
-#[cfg(not(any(target_arch = "powerpc", target_arch = "mips", target_arch = "x86", target_arch = "arm", target_arch = "x86_64", target_arch = "aarch64")))]
+#[cfg(not(any(target_arch = "powerpc",
+              target_arch = "mips",
+              target_arch = "x86",
+              target_arch = "arm",
+              target_arch = "x86_64",
+              target_arch = "aarch64")))]
 use this_arch_not_supported;
 
 // "Generic" ioctl protocol
-#[cfg(any(target_arch = "x86", target_arch = "arm", target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(target_arch = "x86",
+          target_arch = "arm",
+          target_arch = "x86_64",
+          target_arch = "aarch64"))]
 mod consts {
-    #[doc(hidden)]
     pub const NONE: u8 = 0;
-    #[doc(hidden)]
     pub const READ: u8 = 2;
-    #[doc(hidden)]
     pub const WRITE: u8 = 1;
-    #[doc(hidden)]
     pub const SIZEBITS: u8 = 14;
-    #[doc(hidden)]
     pub const DIRBITS: u8 = 2;
 }
 
-#[doc(hidden)]
 pub use self::consts::*;
 
-#[doc(hidden)]
 pub const NRSHIFT: u32 = 0;
-#[doc(hidden)]
 pub const TYPESHIFT: u32 = NRSHIFT + NRBITS as u32;
-#[doc(hidden)]
 pub const SIZESHIFT: u32 = TYPESHIFT + TYPEBITS as u32;
-#[doc(hidden)]
 pub const DIRSHIFT: u32 = SIZESHIFT + SIZEBITS as u32;
 
-#[doc(hidden)]
 pub const NRMASK: u32 = (1 << NRBITS) - 1;
-#[doc(hidden)]
 pub const TYPEMASK: u32 = (1 << TYPEBITS) - 1;
-#[doc(hidden)]
 pub const SIZEMASK: u32 = (1 << SIZEBITS) - 1;
-#[doc(hidden)]
 pub const DIRMASK: u32 = (1 << DIRBITS) - 1;
 
 /// Encode an ioctl command.
@@ -190,11 +177,7 @@ pub fn ioc_size(nr: u32) -> u32 {
     ((nr >> SIZESHIFT) as u32) & SIZEMASK
 }
 
-#[doc(hidden)]
 pub const IN: u32 = (WRITE as u32) << DIRSHIFT;
-#[doc(hidden)]
 pub const OUT: u32 = (READ as u32) << DIRSHIFT;
-#[doc(hidden)]
 pub const INOUT: u32 = ((READ|WRITE) as u32) << DIRSHIFT;
-#[doc(hidden)]
 pub const SIZE_MASK: u32 = SIZEMASK << SIZESHIFT;

--- a/src/sys/ioctl/platform/linux.rs
+++ b/src/sys/ioctl/platform/linux.rs
@@ -95,59 +95,59 @@ macro_rules! convert_ioctl_res {
 #[macro_export]
 macro_rules! ioctl {
     (bad $name:ident with $nr:expr) => (
-        unsafe fn $name(fd: $crate::sys::ioctl::libc::c_int,
-                        data: *mut u8)
-                        -> $crate::Result<$crate::sys::ioctl::libc::c_int> {
+        pub unsafe fn $name(fd: $crate::sys::ioctl::libc::c_int,
+                            data: *mut u8)
+                            -> $crate::Result<$crate::sys::ioctl::libc::c_int> {
             convert_ioctl_res!($crate::sys::ioctl::ioctl(fd, $nr as $crate::sys::ioctl::libc::c_ulong, data))
         }
         );
     (none $name:ident with $ioty:expr, $nr:expr) => (
-        unsafe fn $name(fd: $crate::sys::ioctl::libc::c_int)
-                        -> $crate::Result<$crate::sys::ioctl::libc::c_int> {
+        pub unsafe fn $name(fd: $crate::sys::ioctl::libc::c_int)
+                            -> $crate::Result<$crate::sys::ioctl::libc::c_int> {
             convert_ioctl_res!($crate::sys::ioctl::ioctl(fd, io!($ioty, $nr) as $crate::sys::ioctl::libc::c_ulong))
         }
         );
     (read $name:ident with $ioty:expr, $nr:expr; $ty:ty) => (
-        unsafe fn $name(fd: $crate::sys::ioctl::libc::c_int,
-                        val: *mut $ty)
-                        -> $crate::Result<$crate::sys::ioctl::libc::c_int> {
+        pub unsafe fn $name(fd: $crate::sys::ioctl::libc::c_int,
+                            val: *mut $ty)
+                            -> $crate::Result<$crate::sys::ioctl::libc::c_int> {
             convert_ioctl_res!($crate::sys::ioctl::ioctl(fd, ior!($ioty, $nr, ::std::mem::size_of::<$ty>()) as $crate::sys::ioctl::libc::c_ulong, val))
         }
         );
     (write $name:ident with $ioty:expr, $nr:expr; $ty:ty) => (
-        unsafe fn $name(fd: $crate::sys::ioctl::libc::c_int,
-                        val: *const $ty)
-                         -> $crate::Result<$crate::sys::ioctl::libc::c_int> {
+        pub unsafe fn $name(fd: $crate::sys::ioctl::libc::c_int,
+                            val: *const $ty)
+                            -> $crate::Result<$crate::sys::ioctl::libc::c_int> {
             convert_ioctl_res!($crate::sys::ioctl::ioctl(fd, iow!($ioty, $nr, ::std::mem::size_of::<$ty>()) as $crate::sys::ioctl::libc::c_ulong, val))
         }
         );
     (readwrite $name:ident with $ioty:expr, $nr:expr; $ty:ty) => (
-        unsafe fn $name(fd: $crate::sys::ioctl::libc::c_int,
-                        val: *mut $ty)
-                        -> $crate::Result<$crate::sys::ioctl::libc::c_int> {
+        pub unsafe fn $name(fd: $crate::sys::ioctl::libc::c_int,
+                            val: *mut $ty)
+                            -> $crate::Result<$crate::sys::ioctl::libc::c_int> {
             convert_ioctl_res!($crate::sys::ioctl::ioctl(fd, iorw!($ioty, $nr, ::std::mem::size_of::<$ty>()) as $crate::sys::ioctl::libc::c_ulong, val))
         }
         );
     (read buf $name:ident with $ioty:expr, $nr:expr; $ty:ty) => (
-        unsafe fn $name(fd: $crate::sys::ioctl::libc::c_int,
-                        val: *mut $ty,
-                        len: usize)
-                        -> $crate::Result<$crate::sys::ioctl::libc::c_int> {
+        pub unsafe fn $name(fd: $crate::sys::ioctl::libc::c_int,
+                            val: *mut $ty,
+                            len: usize)
+                            -> $crate::Result<$crate::sys::ioctl::libc::c_int> {
             convert_ioctl_res!($crate::sys::ioctl::ioctl(fd, ior!($ioty, $nr, len) as $crate::sys::ioctl::libc::c_ulong, val))
         }
         );
     (write buf $name:ident with $ioty:expr, $nr:expr; $ty:ty) => (
-        unsafe fn $name(fd: $crate::sys::ioctl::libc::c_int,
-                        val: *const $ty,
-                        len: usize) -> $crate::Result<$crate::sys::ioctl::libc::c_int> {
+        pub unsafe fn $name(fd: $crate::sys::ioctl::libc::c_int,
+                            val: *const $ty,
+                            len: usize) -> $crate::Result<$crate::sys::ioctl::libc::c_int> {
             convert_ioctl_res!($crate::sys::ioctl::ioctl(fd, iow!($ioty, $nr, len) as $crate::sys::ioctl::libc::c_ulong, val))
         }
         );
     (readwrite buf $name:ident with $ioty:expr, $nr:expr; $ty:ty) => (
-        unsafe fn $name(fd: $crate::sys::ioctl::libc::c_int,
-                        val: *const $ty,
-                        len: usize)
-                        -> $crate::Result<$crate::sys::ioctl::libc::c_int> {
+        pub unsafe fn $name(fd: $crate::sys::ioctl::libc::c_int,
+                            val: *const $ty,
+                            len: usize)
+                            -> $crate::Result<$crate::sys::ioctl::libc::c_int> {
             convert_ioctl_res!($crate::sys::ioctl::ioctl(fd, iorw!($ioty, $nr, len) as $crate::sys::ioctl::libc::c_ulong, val))
         }
         );


### PR DESCRIPTION
This set of changes addresses the inability to expose a public interface by making generating functions for `ioctl!` public.  It also includes documentation improvements and some code cleanup.

I have some other ideas for ways to enhance the ioctl! macros to support other common use cases better but am holding off on them for the moment.