### PR TITLE
Add signalfd support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ exclude     = [
 ]
 
 [features]
-
 eventfd = []
 execvpe = []
 
@@ -30,6 +29,11 @@ path    = "nix-test"
 version = "*"
 
 [[test]]
-
 name = "test"
 path = "test/test.rs"
+
+[[test]]
+name = "test-signalfd"
+path = "test/test_signalfd.rs"
+harness = false
+test = true

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -17,6 +17,9 @@ pub mod ioctl;
 
 pub mod signal;
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub mod signalfd;
+
 pub mod socket;
 
 pub mod stat;

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -158,7 +158,7 @@ pub mod signal {
     );
 
     bitflags!{
-        flags HowFlag: libc:c_int {
+        flags HowFlag: libc::c_int {
             const SIG_BLOCK   = 1,
             const SIG_UNBLOCK = 2,
             const SIG_SETMASK = 3,
@@ -237,7 +237,7 @@ pub mod signal {
     );
 
     bitflags!{
-        flags HowFlag: libc:c_int {
+        flags HowFlag: libc::c_int {
             const SIG_BLOCK   = 1,
             const SIG_UNBLOCK = 2,
             const SIG_SETMASK = 3,

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -108,9 +108,9 @@ pub mod signal {
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct siginfo {
-        si_signo: libc::c_int,
-        si_errno: libc::c_int,
-        si_code: libc::c_int,
+        pub si_signo: libc::c_int,
+        pub si_errno: libc::c_int,
+        pub si_code: libc::c_int,
         pub pid: libc::pid_t,
         pub uid: libc::uid_t,
         pub status: libc::c_int,
@@ -193,9 +193,9 @@ pub mod signal {
     // however.
     #[repr(C)]
     pub struct siginfo {
-        si_signo: libc::c_int,
-        si_code: libc::c_int,
-        si_errno: libc::c_int,
+        pub si_signo: libc::c_int,
+        pub si_code: libc::c_int,
+        pub si_errno: libc::c_int,
         pub pid: libc::pid_t,
         pub uid: libc::uid_t,
         pub status: libc::c_int,

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -417,6 +417,12 @@ impl SigSet {
     }
 }
 
+impl AsRef<sigset_t> for SigSet {
+    fn as_ref(&self) -> &sigset_t {
+        &self.sigset
+    }
+}
+
 type sigaction_t = self::signal::sigaction;
 
 pub struct SigAction {

--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -22,7 +22,7 @@ use errno::Errno;
 use sys::signal::signal::siginfo as signal_siginfo;
 pub use sys::signal::{self, SigSet};
 
-use std::os::unix::io::RawFd;
+use std::os::unix::io::{RawFd, AsRawFd, FromRawFd};
 use std::mem;
 
 mod ffi {
@@ -126,6 +126,18 @@ impl SignalFd {
 impl Drop for SignalFd {
     fn drop(&mut self) {
         let _ = unistd::close(self.0);
+    }
+}
+
+impl AsRawFd for SignalFd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0
+    }
+}
+
+impl FromRawFd for SignalFd {
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        SignalFd(fd)
     }
 }
 

--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -1,0 +1,160 @@
+use libc::{c_int, pid_t, uid_t};
+use {Error, Result};
+use unistd;
+use errno::Errno;
+use sys::signal::signal::siginfo as signal_siginfo;
+pub use sys::signal::{self, SigSet};
+
+use std::os::unix::io::RawFd;
+use std::mem;
+
+mod ffi {
+    use libc::c_int;
+    use sys::signal::sigset_t;
+
+    extern {
+        pub fn signalfd(fd: c_int, mask: *const sigset_t, flags: c_int) -> c_int;
+    }
+}
+
+bitflags!{
+    flags SfdFlags: c_int {
+        const SFD_NONBLOCK  = 0o00004000, // O_NONBLOCK
+        const SFD_CLOEXEC   = 0o02000000, // O_CLOEXEC
+    }
+}
+
+pub const CREATE_NEW_FD: RawFd = -1;
+
+/// Creates a new file descriptor for reading signals.
+///
+/// The `mask` parameter specifies the set of signals that can be accepted via this file descriptor.
+///
+/// See [the signalfd man page for more information](http://man7.org/linux/man-pages/man2/signalfd.2.html)
+pub fn signalfd(fd: RawFd, mask: &SigSet, flags: SfdFlags) -> Result<RawFd> {
+    unsafe {
+        match ffi::signalfd(fd as c_int, mask.as_ref(), flags.bits()) {
+            -1 => Err(Error::Sys(Errno::last())),
+            res => Ok(res as RawFd),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SignalFd(RawFd);
+
+impl SignalFd {
+    pub fn new(mask: &SigSet) -> Result<SignalFd> {
+        Self::with_flags(mask, SfdFlags::empty())
+    }
+
+    pub fn with_flags(mask: &SigSet, flags: SfdFlags) -> Result<SignalFd> {
+        let fd = try!(signalfd(CREATE_NEW_FD, mask, flags));
+
+        Ok(SignalFd(fd))
+    }
+
+    pub fn set_mask(&mut self, mask: &SigSet) -> Result<()> {
+        signalfd(self.0, mask, SfdFlags::empty()).map(|_| ())
+    }
+
+    pub fn read_signal(&mut self) -> Result<Option<siginfo>> {
+        let mut buffer: [u8; SIGINFO_SIZE] = unsafe { mem::uninitialized() };
+
+        match unistd::read(self.0, &mut buffer) {
+            Ok(SIGINFO_SIZE) => Ok(Some(unsafe { mem::transmute_copy(&buffer) })),
+            Ok(_) => unreachable!("partial read on signalfd"),
+            Err(Error::Sys(Errno::EAGAIN)) => Ok(None),
+            Err(error) => Err(error)
+        }
+    }
+}
+
+impl Drop for SignalFd {
+    fn drop(&mut self) {
+        let _ = unistd::close(self.0);
+    }
+}
+
+impl Iterator for SignalFd {
+    type Item = siginfo;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.read_signal() {
+            Ok(Some(sig)) => Some(sig),
+            Ok(None) => None,
+            Err(..) => None,
+        }
+    }
+}
+
+pub const SIGINFO_SIZE: usize = 128;
+pub const SIGINFO_PADDING: usize = 48;
+
+#[derive(Debug, Clone, PartialEq)]
+#[repr(C, packed)]
+pub struct siginfo {
+    pub ssi_signo: u32,
+    pub ssi_errno: i32,
+    pub ssi_code: i32,
+    pub ssi_pid: u32,
+    pub ssi_uid: u32,
+    pub ssi_fd: i32,
+    pub ssi_tid: u32,
+    pub ssi_band: u32,
+    pub ssi_overrun: u32,
+    pub ssi_trapno: u32,
+    pub ssi_status: i32,
+    pub ssi_int: i32,
+    pub ssi_ptr: u64,
+    pub ssi_utime: u64,
+    pub ssi_stime: u64,
+    pub ssi_addr: u64,
+}
+
+impl Into<signal_siginfo> for siginfo {
+    fn into(self) -> signal_siginfo {
+        signal_siginfo {
+            si_signo: self.ssi_signo as c_int,
+            si_errno: self.ssi_errno as c_int,
+            si_code: self.ssi_code as c_int,
+            pid: self.ssi_pid as pid_t,
+            uid: self.ssi_uid as uid_t,
+            status: self.ssi_status as c_int,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem;
+
+    #[test]
+    fn check_siginfo_size() {
+        assert_eq!(mem::size_of::<siginfo>() + SIGINFO_PADDING, SIGINFO_SIZE);
+    }
+
+    #[test]
+    fn create_signalfd() {
+        let mask = SigSet::empty();
+        let fd = SignalFd::new(&mask);
+        assert!(fd.is_ok());
+    }
+
+    #[test]
+    fn create_signalfd_with_opts() {
+        let mask = SigSet::empty();
+        let fd = SignalFd::with_flags(&mask, SFD_CLOEXEC | SFD_NONBLOCK);
+        assert!(fd.is_ok());
+    }
+
+    #[test]
+    fn read_empty_signalfd() {
+        let mask = SigSet::empty();
+        let mut fd = SignalFd::with_flags(&mask, SFD_NONBLOCK).unwrap();
+
+        let res = fd.read_signal();
+        assert_eq!(res, Ok(None));
+    }
+}

--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -22,7 +22,7 @@ use errno::Errno;
 use sys::signal::signal::siginfo as signal_siginfo;
 pub use sys::signal::{self, SigSet};
 
-use std::os::unix::io::{RawFd, AsRawFd, FromRawFd};
+use std::os::unix::io::{RawFd, AsRawFd};
 use std::mem;
 
 mod ffi {

--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -135,12 +135,6 @@ impl AsRawFd for SignalFd {
     }
 }
 
-impl FromRawFd for SignalFd {
-    unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        SignalFd(fd)
-    }
-}
-
 impl Iterator for SignalFd {
     type Item = siginfo;
 

--- a/test/test_signalfd.rs
+++ b/test/test_signalfd.rs
@@ -1,8 +1,11 @@
 extern crate nix;
 
 use nix::unistd;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use nix::sys::signalfd::*;
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn main() {
     let mut mask = SigSet::empty();
     mask.add(signal::SIGUSR1).unwrap();
@@ -22,3 +25,6 @@ fn main() {
     let info = opt.unwrap();
     assert_eq!(info.ssi_signo as i32, signal::SIGUSR1);
 }
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn main() {}

--- a/test/test_signalfd.rs
+++ b/test/test_signalfd.rs
@@ -1,0 +1,24 @@
+extern crate nix;
+
+use nix::unistd;
+use nix::sys::signalfd::*;
+
+fn main() {
+    let mut mask = SigSet::empty();
+    mask.add(signal::SIGUSR1).unwrap();
+    mask.thread_block().unwrap();
+
+    let mut fd = SignalFd::new(&mask).unwrap();
+
+    let pid = unistd::getpid();
+    signal::kill(pid, signal::SIGUSR1).unwrap();
+
+    let res = fd.read_signal();
+    assert!(res.is_ok());
+
+    let opt = res.ok().unwrap();
+    assert!(opt.is_some());
+
+    let info = opt.unwrap();
+    assert_eq!(info.ssi_signo as i32, signal::SIGUSR1);
+}


### PR DESCRIPTION
This PR adds support for `signalfd`, a Linux exclusive method to receive signals via a file descriptor.

Also includes:
- added support for blocking signals in `sys::signal`: `signalfd` requires blocking the signals from their normal signal handlers
- added some helper functions to `sys::signal::SigSet`: querying set membership, signal blocking helpers, etc...
- unit tests for signal blocking and `signalfd` reading

Tested with Linux + Rust 1.2 on: x86, x86_64, arm(raspberry pi)

If and when this gets merged, I will add support for signal handling via signalfd + epoll to `mio`.