### PR TITLE
Fix handling of sockaddr_un lengths

### DIFF
--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -687,8 +687,7 @@ pub unsafe fn sockaddr_storage_to_addr(
             Ok(SockAddr::Inet(InetAddr::V6((*(addr as *const _ as *const sockaddr_in6)))))
         }
         consts::AF_UNIX => {
-            assert!(len as usize == mem::size_of::<sockaddr_un>());
-            Ok(SockAddr::Unix(UnixAddr(*(addr as *const _ as *const sockaddr_un))))
+            Ok(SockAddr::Unix(UnixAddr(*(addr as *const _ as *const sockaddr_un), len)))
         }
         af => panic!("unexpected address family {}", af),
     }

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -35,7 +35,7 @@ pub fn test_path_to_sock_addr() {
     let expect: &'static [i8] = unsafe { mem::transmute(&b"/foo/bar"[..]) };
     assert_eq!(&addr.0.sun_path[..8], expect);
 
-    assert_eq!(addr.path(), actual);
+    assert_eq!(addr.path(), Some(actual));
 }
 
 #[test]


### PR DESCRIPTION
The returned length of AF_UNIX sockaddrs is significant, and generally
does not match the length of the entire structure. For filesystem
sockets, this is ignorable because the path is also NUL-terminated, but
for unbound sockets (e.g., a socketpair) or abstract-namespace
sockets (a Linux extension where the address is an arbitrary
bytestring), we need to keep track of the length.

Fixes #177. Also add a UnixAddr::new_abstract function and some better
handling of abstract-namespace socket addresses to fix #169.