### PR TITLE
update libc to 0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ preadv_pwritev = []
 signalfd = []
 
 [dependencies]
-libc     = "0.1.12"
-bitflags = "0.3.2"
+libc     = "0.2.2"
+bitflags = "0.3.3"
 
 [dev-dependencies]
 rand = "0.3.8"

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -11,8 +11,8 @@ pub use self::ffi::flock;
 mod ffi {
     pub use libc::{open, fcntl};
     pub use self::os::*;
-    pub use libc::funcs::bsd44::flock as libc_flock;
-    pub use libc::consts::os::bsd44::{LOCK_SH, LOCK_EX, LOCK_NB, LOCK_UN};
+    pub use libc::flock as libc_flock;
+    pub use libc::{LOCK_SH, LOCK_EX, LOCK_NB, LOCK_UN};
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
     mod os {

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -1,6 +1,6 @@
 use {Error, Result, NixPath};
 use errno::Errno;
-use libc::{mode_t, c_int};
+use libc::{c_int, c_uint};
 use sys::stat::Mode;
 use std::os::unix::io::RawFd;
 
@@ -99,7 +99,7 @@ mod ffi {
 
 pub fn open<P: ?Sized + NixPath>(path: &P, oflag: OFlag, mode: Mode) -> Result<RawFd> {
     let fd = try!(path.with_nix_path(|cstr| {
-        unsafe { ffi::open(cstr.as_ptr(), oflag.bits(), mode.bits() as mode_t) }
+        unsafe { ffi::open(cstr.as_ptr(), oflag.bits(), mode.bits() as c_uint) }
     }));
 
     if fd < 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ pub mod unistd;
  *
  */
 
-use libc::{c_char, PATH_MAX};
+use libc::c_char;
 use std::{ptr, result};
 use std::ffi::CStr;
 use std::path::{Path, PathBuf};
@@ -51,6 +51,14 @@ use std::os::unix::ffi::OsStrExt;
 use std::io;
 use std::fmt;
 use std::error;
+
+#[cfg(any(target_os = "openbsd", target_os = "netbsd", target_os = "bitrig", target_os = "macos", target_os = "ios"))]
+use libc::PATH_MAX;
+#[cfg(not(any(target_os = "openbsd", target_os = "netbsd", target_os = "bitrig", target_os = "macos", target_os = "ios")))]
+const PATH_MAX: c_int = 1024;
+
+
+
 
 pub type Result<T> = result::Result<T, Error>;
 

--- a/src/mqueue.rs
+++ b/src/mqueue.rs
@@ -41,6 +41,7 @@ mod ffi {
     use super::MQd;
     use super::MqAttr;
 
+    #[allow(improper_ctypes)]
     extern "C" {
         pub fn mq_open(name: *const c_char, oflag: c_int, ...) -> MQd;
 

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -179,7 +179,7 @@ mod ffi {
 
     pub use libc::{mmap, munmap};
 
-
+    #[allow(improper_ctypes)]
     extern {
         pub fn shm_open(name: *const c_char, oflag: c_int, mode: mode_t) -> c_int;
         pub fn shm_unlink(name: *const c_char) -> c_int;

--- a/src/sys/quota.rs
+++ b/src/sys/quota.rs
@@ -15,7 +15,7 @@ pub mod quota {
 
 	impl QuotaCmd {
 		pub fn as_int(&self) -> c_int {
-			((self.0 << 8) | (self.1 & 0x00ff)) as c_int 
+			((self.0 << 8) | (self.1 & 0x00ff)) as c_int
 		}
 	}
 
@@ -97,7 +97,7 @@ fn quotactl<P: ?Sized + NixPath>(cmd: quota::QuotaCmd, special: Option<&P>, id: 
 pub fn quotactl_on<P: ?Sized + NixPath>(which: quota::QuotaType, special: &P, format: quota::QuotaFmt, quota_file: &P) -> Result<()> {
 	try!(quota_file.with_nix_path(|path| {
 		let mut path_copy = path.to_bytes_with_nul().to_owned();
-		let p: *mut i8 = path_copy.as_mut_ptr() as *mut i8;
+		let p: *mut c_char = path_copy.as_mut_ptr() as *mut c_char;
 		quotactl(quota::QuotaCmd(quota::Q_QUOTAON, which), Some(special), format as c_int, p)
 	}))
 }

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -7,7 +7,7 @@ use std::mem;
 use std::ptr;
 use {Error, Result};
 
-pub use libc::consts::os::posix88::{
+pub use libc::{
     SIGHUP,   // 1
     SIGINT,   // 2
     SIGQUIT,  // 3

--- a/src/sys/socket/consts.rs
+++ b/src/sys/socket/consts.rs
@@ -204,9 +204,9 @@ mod os {
     pub const IP_ADD_MEMBERSHIP: c_int = 12;
     pub const IP_DROP_MEMBERSHIP: c_int = 13;
 
-    #[cfg(not(target_os = "netbsd"))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "netbsd", target_os = "dragonfly")))]
     pub const IPV6_ADD_MEMBERSHIP: c_int = libc::IPV6_ADD_MEMBERSHIP;
-    #[cfg(not(target_os = "netbsd"))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "netbsd", target_os = "dragonfly")))]
     pub const IPV6_DROP_MEMBERSHIP: c_int = libc::IPV6_DROP_MEMBERSHIP;
 
     #[cfg(target_os = "netbsd")]

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -121,9 +121,9 @@ sockopt_impl!(Both, TcpNoDelay, consts::IPPROTO_TCP, consts::TCP_NODELAY, bool);
 sockopt_impl!(Both, Linger, consts::SOL_SOCKET, consts::SO_LINGER, super::linger);
 sockopt_impl!(SetOnly, IpAddMembership, consts::IPPROTO_IP, consts::IP_ADD_MEMBERSHIP, super::ip_mreq);
 sockopt_impl!(SetOnly, IpDropMembership, consts::IPPROTO_IP, consts::IP_DROP_MEMBERSHIP, super::ip_mreq);
-#[cfg(not(target_os = "netbsd"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "netbsd", target_os = "dragonfly")))]
 sockopt_impl!(SetOnly, Ipv6AddMembership, consts::IPPROTO_IPV6, consts::IPV6_ADD_MEMBERSHIP, super::ipv6_mreq);
-#[cfg(not(target_os = "netbsd"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "netbsd", target_os = "dragonfly")))]
 sockopt_impl!(SetOnly, Ipv6DropMembership, consts::IPPROTO_IPV6, consts::IPV6_DROP_MEMBERSHIP, super::ipv6_mreq);
 #[cfg(target_os = "netbsd")]
 sockopt_impl!(SetOnly, Ipv6AddMembership, consts::IPPROTO_IPV6, consts::IPV6_JOIN_GROUP, super::ipv6_mreq);

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -14,8 +14,7 @@ pub use self::linux::*;
 
 mod ffi {
     use libc::{c_char, c_int, size_t};
-    pub use libc::{close, read, write, pipe, ftruncate, unlink, setpgid};
-    pub use libc::funcs::posix88::unistd::{fork, getpid, getppid};
+    pub use libc::{close, read, write, pipe, ftruncate, unlink, setpgid, fork, getpid, getppid};
 
     extern {
         // duplicate a file descriptor

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -16,6 +16,7 @@ mod ffi {
     use libc::{c_char, c_int, size_t};
     pub use libc::{close, read, write, pipe, ftruncate, unlink, setpgid, fork, getpid, getppid};
 
+    #[allow(improper_ctypes)]
     extern {
         // duplicate a file descriptor
         // doc: http://man7.org/linux/man-pages/man2/dup.2.html

--- a/test/sys/test_socket.rs
+++ b/test/sys/test_socket.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::str::FromStr;
 use std::os::unix::io::{AsRawFd, RawFd};
 use ports::localhost;
+use libc::c_char;
 
 #[test]
 pub fn test_inetv4_addr_to_sock_addr() {
@@ -32,7 +33,7 @@ pub fn test_path_to_sock_addr() {
     let actual = Path::new("/foo/bar");
     let addr = UnixAddr::new(actual).unwrap();
 
-    let expect: &'static [i8] = unsafe { mem::transmute(&b"/foo/bar"[..]) };
+    let expect: &'static [c_char] = unsafe { mem::transmute(&b"/foo/bar"[..]) };
     assert_eq!(&addr.0.sun_path[..8], expect);
 
     assert_eq!(addr.path(), Some(actual));

--- a/test/sys/test_wait.rs
+++ b/test/sys/test_wait.rs
@@ -2,7 +2,7 @@ use nix::unistd::*;
 use nix::unistd::Fork::*;
 use nix::sys::signal::*;
 use nix::sys::wait::*;
-use libc::funcs::c95::stdlib::exit;
+use libc::exit;
 
 #[test]
 fn test_wait_signal() {

--- a/test/test_stat.rs
+++ b/test/test_stat.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::str;
 
-use libc::consts::os::posix88;
+use libc::{S_IFMT, S_IFLNK};
 
 use nix::sys::stat::{stat, fstat, lstat};
 
@@ -40,8 +40,7 @@ fn assert_lstat_results(stat_result: Result<FileStat>) {
             // st_mode is c_uint (u32 on Android) while S_IFMT is mode_t
             // (u16 on Android), and that will be a compile error.
             // On other platforms they are the same (either both are u16 or u32).
-            assert!((stats.st_mode as usize) & (posix88::S_IFMT as usize)
-                    == posix88::S_IFLNK as usize); // should be a link
+            assert!((stats.st_mode as usize) & (S_IFMT as usize) == S_IFLNK as usize); // should be a link
             assert!(stats.st_nlink == 1);   // there links created, must be 1
             // uid could be 0 for the `root` user. This quite possible when
             // the tests are being run on a rooted Android device.


### PR DESCRIPTION
Nix is broken on nightly arm because of:
https://github.com/rust-lang/rust/pull/29775

This fixes nix for arm nightly, but breaks on arm stable. Should work on x86 stable and nightly.
Maybe this could be put into a separate nightly branch that could be pointed to in Cargo.toml?