### PR TITLE
add NSIG constant

### DIFF
--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -41,6 +41,8 @@ pub use self::signal::{
     SIGWINCH,
     SIGUSR1,
     SIGUSR2,
+
+    NSIG,
 };
 
 pub use self::signal::SockFlag;
@@ -101,6 +103,8 @@ pub mod signal {
     pub const SIGPWR:       libc::c_int = 30;
     pub const SIGSYS:       libc::c_int = 31;
     pub const SIGUNUSED:    libc::c_int = 31;
+
+    pub const NSIG:         libc::c_int = 32;
 
     // This definition is not as accurate as it could be, {pid, uid, status} is
     // actually a giant union. Currently we're only interested in these fields,
@@ -188,6 +192,8 @@ pub mod signal {
     pub const SIGXCPU:      libc::c_int = 30;
     pub const SIGFSZ:       libc::c_int = 31;
 
+    pub const NSIG:         libc::c_int = 32;
+
     // This definition is not as accurate as it could be, {pid, uid, status} is
     // actually a giant union. Currently we're only interested in these fields,
     // however.
@@ -265,6 +271,8 @@ pub mod signal {
     pub const SIGINFO:      libc::c_int = 29;
     pub const SIGUSR1:      libc::c_int = 30;
     pub const SIGUSR2:      libc::c_int = 31;
+
+    pub const NSIG:         libc::c_int = 32;
 
     #[cfg(any(target_os = "macos", target_os = "ios", target_os = "openbsd"))]
     pub type sigset_t = u32;


### PR DESCRIPTION
glibc defines this constant as "the total number of signals defined.
Since the signal numbers are allocated consecutively, NSIG is also one
greater than the largest defined signal number."