### PR TITLE
typo: MNT_DETATCH -> MNT_DETACH

### DIFF
--- a/src/mount.rs
+++ b/src/mount.rs
@@ -43,7 +43,7 @@ bitflags!(
 bitflags!(
     flags MntFlags: c_int {
         const MNT_FORCE   = 1 << 0,
-        const MNT_DETATCH = 1 << 1,
+        const MNT_DETACH  = 1 << 1,
         const MNT_EXPIRE  = 1 << 2
     }
 );


### PR DESCRIPTION
I believe the T should not be there: http://linux.die.net/man/2/umount2