### PR TITLE
add aarch64 support

### DIFF
--- a/src/sched.rs
+++ b/src/sched.rs
@@ -63,6 +63,23 @@ mod cpuset_attribs {
     }
 }
 
+#[cfg(all(target_arch = "aarch64", any(target_os = "linux", target_os = "android")))]
+mod cpuset_attribs {
+    use super::CpuMask;
+    pub const CPU_SETSIZE:           usize = 1024;
+    pub const CPU_MASK_BITS:         usize = 64;
+
+    #[inline]
+    pub fn set_cpu_mask_flag(cur: CpuMask, bit: usize) -> CpuMask {
+        cur | (1u64 << bit)
+    }
+
+    #[inline]
+    pub fn clear_cpu_mask_flag(cur: CpuMask, bit: usize) -> CpuMask {
+        cur & !(1u64 << bit)
+    }
+}
+
 #[cfg(all(target_arch = "arm", any(target_os = "linux", target_os = "android")))]
 mod cpuset_attribs {
     use super::CpuMask;

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -55,6 +55,7 @@ pub const SIGEMT: libc::c_int = 7;
 #[cfg(any(all(target_os = "linux",
               any(target_arch = "x86",
                   target_arch = "x86_64",
+                  target_arch = "aarch64",
                   target_arch = "arm")),
           target_os = "android"))]
 pub mod signal {

--- a/src/sys/syscall.rs
+++ b/src/sys/syscall.rs
@@ -24,6 +24,16 @@ mod arch {
     pub static MEMFD_CREATE: Syscall = 356;
 }
 
+#[cfg(target_arch = "aarch64")]
+mod arch {
+    use libc::c_long;
+
+    pub type Syscall = c_long;
+
+    pub static SYSPIVOTROOT: Syscall = 41;
+    pub static MEMFD_CREATE: Syscall = 279;
+}
+
 #[cfg(target_arch = "arm")]
 mod arch {
     use libc::c_long;


### PR DESCRIPTION
I would like to get aarch64 support merged in. It compiles successfully when targeting `aarch64-unknown-linux-gnu` Also tested through a project using mio which I have actually run on a machine using this architecture.  