### PR TITLE
Account for the different signal handler types.

### DIFF
--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -464,6 +464,15 @@ impl AsRef<sigset_t> for SigSet {
     }
 }
 
+pub use self::signal::siginfo;
+
+pub enum SigHandler {
+    SigDfl,
+    SigIgn,
+    Handler(extern fn(SigNum)),
+    SigAction(extern fn(SigNum, *mut siginfo, *mut libc::c_void))
+}
+
 type sigaction_t = self::signal::sigaction;
 
 pub struct SigAction {
@@ -471,9 +480,14 @@ pub struct SigAction {
 }
 
 impl SigAction {
-    pub fn new(handler: extern fn(libc::c_int), flags: SockFlag, mask: SigSet) -> SigAction {
+    pub fn new(handler: SigHandler, flags: SockFlag, mask: SigSet) -> SigAction {
         let mut s = unsafe { mem::uninitialized::<sigaction_t>() };
-        s.sa_handler = handler;
+        s.sa_handler = match handler {
+            SigHandler::SigDfl => unsafe { mem::transmute(libc::SIG_DFL) },
+            SigHandler::SigIgn => unsafe { mem::transmute(libc::SIG_IGN) },
+            SigHandler::Handler(f) => f,
+            SigHandler::SigAction(f) => unsafe { mem::transmute(f) },
+        };
         s.sa_flags = flags;
         s.sa_mask = mask.sigset;
 

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -480,6 +480,8 @@ pub struct SigAction {
 }
 
 impl SigAction {
+    /// This function will set or unset the flag `SA_SIGINFO` depending on the
+    /// type of the `handler` argument.
     pub fn new(handler: SigHandler, flags: SockFlag, mask: SigSet) -> SigAction {
         let mut s = unsafe { mem::uninitialized::<sigaction_t>() };
         s.sa_handler = match handler {
@@ -488,7 +490,10 @@ impl SigAction {
             SigHandler::Handler(f) => f,
             SigHandler::SigAction(f) => unsafe { mem::transmute(f) },
         };
-        s.sa_flags = flags;
+        s.sa_flags = match handler {
+            SigHandler::SigAction(_) => flags | SA_SIGINFO,
+            _ => flags - SA_SIGINFO,
+        };
         s.sa_mask = mask.sigset;
 
         SigAction { sigaction: s }


### PR DESCRIPTION
This commit would be an API breaking change: `nix::sys::signals::sigaction` get's a different signature.

It currently leaves the responsibility of passing the `SA_SIGINFO` flag if necessary to the user.

This might solve part of #49.