### PR TITLE
Add support for SO_{RCV,SEND}BUF(FORCE)? sockopts

### DIFF
--- a/test/sys/mod.rs
+++ b/test/sys/mod.rs
@@ -1,4 +1,5 @@
 mod test_socket;
+mod test_sockopt;
 mod test_termios;
 mod test_ioctl;
 mod test_wait;

--- a/test/sys/test_sockopt.rs
+++ b/test/sys/test_sockopt.rs
@@ -1,0 +1,14 @@
+use rand::{thread_rng, Rng};
+use nix::sys::socket::{socket, sockopt, getsockopt, setsockopt, AddressFamily, SockType, SockFlag, SockLevel};
+
+#[test]
+fn test_so_buf() {
+    let fd = socket(AddressFamily::Inet, SockType::Datagram, SockFlag::empty(), SockLevel::Udp as i32).unwrap();
+    let bufsize: usize = thread_rng().gen_range(4096, 131072);
+    setsockopt(fd, sockopt::SndBuf, &bufsize).unwrap();
+    let actual = getsockopt(fd, sockopt::SndBuf).unwrap();
+    assert!(actual >= bufsize);
+    setsockopt(fd, sockopt::RcvBuf, &bufsize).unwrap();
+    let actual = getsockopt(fd, sockopt::RcvBuf).unwrap();
+    assert!(actual >= bufsize);
+}


### PR DESCRIPTION
This adds support for `SO_RCVBUF`, `SO_SNDBUF` and the forced version on Linux.