### PR TITLE
Errno::result()

### DIFF
--- a/src/errno.rs
+++ b/src/errno.rs
@@ -1,8 +1,9 @@
 use libc::c_int;
+use std::{fmt, io, error, result};
+use Error;
 
 pub use self::consts::*;
 pub use self::consts::Errno::*;
-
 
 #[cfg(any(target_os = "macos",
           target_os = "ios",
@@ -52,27 +53,71 @@ pub fn errno() -> i32 {
     }
 }
 
-macro_rules! impl_errno {
-    ($errno:ty) => {
-        impl $errno {
-            pub fn last() -> Errno {
-                super::last()
-            }
+impl Errno {
+    pub fn last() -> Self {
+        last()
+    }
 
-            pub fn desc(self) -> &'static str {
-                super::desc(self)
-            }
+    pub fn desc(self) -> &'static str {
+        desc(self)
+    }
 
-            pub fn from_i32(err: i32) -> Errno {
-                from_i32(err)
-            }
+    pub fn from_i32(err: i32) -> Errno {
+        from_i32(err)
+    }
 
-            pub unsafe fn clear() -> () {
-                super::clear()
-            }
+    pub unsafe fn clear() -> () {
+        clear()
+    }
+
+    /// Returns `Ok(value)` if it does not contain the sentinel value. This
+    /// should not be used when `-1` is not the errno sentinel value.
+    pub fn result<S: ErrnoSentinel + PartialEq<S>>(value: S) -> Result<S> {
+        if value == S::sentinel() {
+            Err(Error::Sys(Self::last()))
+        } else {
+            Ok(value)
         }
     }
 }
+
+/// The sentinel value indicates that a function failed and more detailed
+/// information about the error can be found in `errno`
+pub trait ErrnoSentinel: Sized {
+    fn sentinel() -> Self;
+}
+
+impl ErrnoSentinel for isize {
+    fn sentinel() -> Self { -1 }
+}
+
+impl ErrnoSentinel for i32 {
+    fn sentinel() -> Self { -1 }
+}
+
+impl ErrnoSentinel for i64 {
+    fn sentinel() -> Self { -1 }
+}
+
+impl error::Error for Errno {
+    fn description(&self) -> &str {
+        self.desc()
+    }
+}
+
+impl fmt::Display for Errno {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}: {}", self, self.desc())
+    }
+}
+
+impl From<Errno> for io::Error {
+    fn from(err: Errno) -> Self {
+        io::Error::from_raw_os_error(err as i32)
+    }
+}
+
+pub type Result<T> = result::Result<T, Error>;
 
 fn last() -> Errno {
     Errno::from_i32(errno())
@@ -618,8 +663,6 @@ mod consts {
         EHWPOISON       = 133,
     }
 
-    impl_errno!(Errno);
-
     pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
     pub const EDEADLOCK:   Errno = Errno::EDEADLK;
 
@@ -880,8 +923,6 @@ mod consts {
         EQFULL          = 106,
     }
 
-    impl_errno!(Errno);
-
     pub const ELAST: Errno       = Errno::EQFULL;
     pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
     pub const EDEADLOCK:   Errno = Errno::EDEADLK;
@@ -1108,8 +1149,6 @@ mod consts {
 
     }
 
-    impl_errno!(Errno);
-
     pub const ELAST: Errno       = Errno::EOWNERDEAD;
     pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
     pub const EDEADLOCK:   Errno = Errno::EDEADLK;
@@ -1330,8 +1369,6 @@ mod consts {
         EASYNC          = 99,
     }
 
-    impl_errno!(Errno);
-
     pub const ELAST: Errno       = Errno::EASYNC;
     pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
     pub const EDEADLOCK:   Errno = Errno::EDEADLK;
@@ -1547,8 +1584,6 @@ mod consts {
         ENOTSUP         = 91,
     }
 
-    impl_errno!(Errno);
-
     pub const ELAST: Errno       = Errno::ENOTSUP;
     pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
 
@@ -1757,8 +1792,6 @@ mod consts {
         ENOLINK		= 95,
         EPROTO		= 96,
     }
-
-    impl_errno!(Errno);
 
     pub const ELAST: Errno       = Errno::ENOTSUP;
     pub const EWOULDBLOCK: Errno = Errno::EAGAIN;

--- a/src/errno.rs
+++ b/src/errno.rs
@@ -1,6 +1,6 @@
 use libc::c_int;
-use std::{fmt, io, error, result};
-use Error;
+use std::{fmt, io, error};
+use {Error, Result};
 
 pub use self::consts::*;
 pub use self::consts::Errno::*;
@@ -116,8 +116,6 @@ impl From<Errno> for io::Error {
         io::Error::from_raw_os_error(err as i32)
     }
 }
-
-pub type Result<T> = result::Result<T, Error>;
 
 fn last() -> Errno {
     Errno::from_i32(errno())

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -1,5 +1,4 @@
-use NixPath;
-use errno::{Errno, Result};
+use {Errno, Result, NixPath};
 use libc::{c_int, c_uint};
 use sys::stat::Mode;
 use std::os::unix::io::RawFd;

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -1,5 +1,5 @@
-use {Error, Result, NixPath};
-use errno::Errno;
+use NixPath;
+use errno::{Errno, Result};
 use libc::{c_int, c_uint};
 use sys::stat::Mode;
 use std::os::unix::io::RawFd;
@@ -102,11 +102,7 @@ pub fn open<P: ?Sized + NixPath>(path: &P, oflag: OFlag, mode: Mode) -> Result<R
         unsafe { ffi::open(cstr.as_ptr(), oflag.bits(), mode.bits() as c_uint) }
     }));
 
-    if fd < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-
-    Ok(fd)
+    Errno::result(fd)
 }
 
 pub enum FcntlArg<'a> {
@@ -157,11 +153,7 @@ pub fn fcntl(fd: RawFd, arg: FcntlArg) -> Result<c_int> {
         }
     };
 
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-
-    Ok(res)
+    Errno::result(res)
 }
 
 pub enum FlockArg {
@@ -187,11 +179,7 @@ pub fn flock(fd: RawFd, arg: FlockArg) -> Result<()> {
         }
     };
 
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-
-    Ok(())
+    Errno::result(res).map(drop)
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,9 @@ extern crate libc;
 #[cfg(test)]
 extern crate nix_test as nixtest;
 
-// Re-export some libc constants
+// Re-exports
 pub use libc::{c_int, c_void};
+pub use errno::{Errno, Result};
 
 pub mod errno;
 pub mod features;
@@ -42,12 +43,12 @@ pub mod unistd;
 
 /*
  *
- * ===== Result / Error =====
+ * ===== Error =====
  *
  */
 
 use libc::c_char;
-use std::{ptr, result};
+use std::ptr;
 use std::ffi::CStr;
 use std::path::{Path, PathBuf};
 use std::os::unix::ffi::OsStrExt;
@@ -55,8 +56,6 @@ use std::io;
 use std::fmt;
 use std::error;
 use libc::PATH_MAX;
-
-pub type Result<T> = result::Result<T, Error>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Error {
@@ -184,13 +183,4 @@ impl NixPath for PathBuf {
     fn with_nix_path<T, F>(&self, f: F) -> Result<T> where F: FnOnce(&CStr) -> T {
         self.as_os_str().as_bytes().with_nix_path(f)
     }
-}
-
-#[inline]
-pub fn from_ffi(res: libc::c_int) -> Result<()> {
-    if res != 0 {
-        return Err(Error::Sys(errno::Errno::last()));
-    }
-
-    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ extern crate nix_test as nixtest;
 
 // Re-exports
 pub use libc::{c_int, c_void};
-pub use errno::{Errno, Result};
+pub use errno::Errno;
 
 pub mod errno;
 pub mod features;
@@ -43,12 +43,12 @@ pub mod unistd;
 
 /*
  *
- * ===== Error =====
+ * ===== Result / Error =====
  *
  */
 
 use libc::c_char;
-use std::ptr;
+use std::{ptr, result};
 use std::ffi::CStr;
 use std::path::{Path, PathBuf};
 use std::os::unix::ffi::OsStrExt;
@@ -56,6 +56,8 @@ use std::io;
 use std::fmt;
 use std::error;
 use libc::PATH_MAX;
+
+pub type Result<T> = result::Result<T, Error>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Error {

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -1,6 +1,5 @@
 use libc::{c_ulong, c_int};
-use NixPath;
-use errno::{Errno, Result};
+use {Errno, Result, NixPath};
 
 bitflags!(
     flags MsFlags: c_ulong {

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -1,5 +1,6 @@
 use libc::{c_ulong, c_int};
-use {Result, NixPath, from_ffi};
+use NixPath;
+use errno::{Errno, Result};
 
 bitflags!(
     flags MsFlags: c_ulong {
@@ -105,7 +106,7 @@ pub fn umount<P: ?Sized + NixPath>(target: &P) -> Result<()> {
         unsafe { ffi::umount(cstr.as_ptr()) }
     }));
 
-    from_ffi(res)
+    Errno::result(res).map(drop)
 }
 
 pub fn umount2<P: ?Sized + NixPath>(target: &P, flags: MntFlags) -> Result<()> {
@@ -113,5 +114,5 @@ pub fn umount2<P: ?Sized + NixPath>(target: &P, flags: MntFlags) -> Result<()> {
         unsafe { ffi::umount2(cstr.as_ptr(), flags.bits) }
     }));
 
-    from_ffi(res)
+    Errno::result(res).map(drop)
 }

--- a/src/mqueue.rs
+++ b/src/mqueue.rs
@@ -2,7 +2,7 @@
 //!
 //! [Further reading and details on the C API](http://man7.org/linux/man-pages/man7/mq_overview.7.html)
 
-use errno::{Errno, Result};
+use {Errno, Result};
 
 use libc::{c_int, c_long, c_char, size_t, mode_t, strlen};
 use std::ffi::CString;

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,5 +1,5 @@
 use libc::c_int;
-use errno::{Errno, Result};
+use {Errno, Result};
 
 pub use self::ffi::PollFd;
 pub use self::ffi::consts::*;

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,6 +1,5 @@
 use libc::c_int;
-use {Error, Result};
-use errno::Errno;
+use errno::{Errno, Result};
 
 pub use self::ffi::PollFd;
 pub use self::ffi::consts::*;
@@ -72,9 +71,5 @@ pub fn poll(fds: &mut [PollFd], timeout: c_int) -> Result<c_int> {
         ffi::poll(fds.as_mut_ptr(), fds.len() as ffi::nfds_t, timeout)
     };
 
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-
-    Ok(res)
+    Errno::result(res)
 }

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -1,8 +1,7 @@
 use std::mem;
 use std::os::unix::io::RawFd;
 use libc::{c_int, c_uint, c_void, c_ulong, pid_t};
-use errno::Errno;
-use {Result, Error};
+use errno::{Errno, Result};
 
 pub type CloneFlags = c_uint;
 
@@ -172,11 +171,7 @@ pub fn sched_setaffinity(pid: isize, cpuset: &CpuSet) -> Result<()> {
         ffi::sched_setaffinity(pid as pid_t, mem::size_of::<CpuSet>() as size_t, mem::transmute(cpuset))
     };
 
-    if res != 0 {
-        Err(Error::Sys(Errno::last()))
-    } else {
-        Ok(())
-    }
+    Errno::result(res).map(drop)
 }
 
 pub fn clone(mut cb: CloneCb, stack: &mut [u8], flags: CloneFlags) -> Result<pid_t> {
@@ -190,29 +185,17 @@ pub fn clone(mut cb: CloneCb, stack: &mut [u8], flags: CloneFlags) -> Result<pid
         ffi::clone(mem::transmute(callback), ptr as *mut c_void, flags, &mut cb)
     };
 
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-
-    Ok(res)
+    Errno::result(res)
 }
 
 pub fn unshare(flags: CloneFlags) -> Result<()> {
     let res = unsafe { ffi::unshare(flags) };
 
-    if res != 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-
-    Ok(())
+    Errno::result(res).map(drop)
 }
 
 pub fn setns(fd: RawFd, nstype: CloneFlags) -> Result<()> {
     let res = unsafe { ffi::setns(fd, nstype) };
 
-    if res != 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-
-    Ok(())
+    Errno::result(res).map(drop)
 }

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -1,7 +1,7 @@
 use std::mem;
 use std::os::unix::io::RawFd;
 use libc::{c_int, c_uint, c_void, c_ulong, pid_t};
-use errno::{Errno, Result};
+use {Errno, Result};
 
 pub type CloneFlags = c_uint;
 

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -1,5 +1,4 @@
-use {Error, Result, from_ffi};
-use errno::Errno;
+use errno::{Errno, Result};
 use libc::c_int;
 use std::os::unix::io::RawFd;
 
@@ -76,17 +75,14 @@ fn test_epoll_event_size() {
 pub fn epoll_create() -> Result<RawFd> {
     let res = unsafe { ffi::epoll_create(1024) };
 
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-
-    Ok(res)
+    Errno::result(res)
 }
 
 #[inline]
 pub fn epoll_ctl(epfd: RawFd, op: EpollOp, fd: RawFd, event: &EpollEvent) -> Result<()> {
     let res = unsafe { ffi::epoll_ctl(epfd, op as c_int, fd, event as *const EpollEvent) };
-    from_ffi(res)
+
+    Errno::result(res).map(drop)
 }
 
 #[inline]
@@ -95,9 +91,5 @@ pub fn epoll_wait(epfd: RawFd, events: &mut [EpollEvent], timeout_ms: isize) -> 
         ffi::epoll_wait(epfd, events.as_mut_ptr(), events.len() as c_int, timeout_ms as c_int)
     };
 
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-
-    Ok(res as usize)
+    Errno::result(res).map(|r| r as usize)
 }

--- a/src/sys/epoll.rs
+++ b/src/sys/epoll.rs
@@ -1,4 +1,4 @@
-use errno::{Errno, Result};
+use {Errno, Result};
 use libc::c_int;
 use std::os::unix::io::RawFd;
 

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -1,8 +1,7 @@
 /* TOOD: Implement for other kqueue based systems
  */
 
-use {Error, Result};
-use errno::Errno;
+use errno::{Errno, Result};
 #[cfg(not(target_os = "netbsd"))]
 use libc::{timespec, time_t, c_int, c_long, uintptr_t};
 #[cfg(target_os = "netbsd")]
@@ -277,11 +276,7 @@ pub const EV_OOBAND: EventFlag = EV_FLAG1;
 pub fn kqueue() -> Result<RawFd> {
     let res = unsafe { ffi::kqueue() };
 
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-
-    Ok(res)
+    Errno::result(res)
 }
 
 pub fn kevent(kq: RawFd,
@@ -314,11 +309,7 @@ pub fn kevent_ts(kq: RawFd,
             if let Some(ref timeout) = timeout_opt {timeout as *const timespec} else {ptr::null()})
     };
 
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-
-    return Ok(res as usize)
+    Errno::result(res).map(|r| r as usize)
 }
 
 #[cfg(target_os = "netbsd")]
@@ -337,11 +328,7 @@ pub fn kevent_ts(kq: RawFd,
             if let Some(ref timeout) = timeout_opt {timeout as *const timespec} else {ptr::null()})
     };
 
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-
-    return Ok(res as usize)
+    Errno::result(res).map(|r| r as usize)
 }
 
 #[cfg(not(target_os = "netbsd"))]

--- a/src/sys/event.rs
+++ b/src/sys/event.rs
@@ -1,7 +1,7 @@
 /* TOOD: Implement for other kqueue based systems
  */
 
-use errno::{Errno, Result};
+use {Errno, Result};
 #[cfg(not(target_os = "netbsd"))]
 use libc::{timespec, time_t, c_int, c_long, uintptr_t};
 #[cfg(target_os = "netbsd")]

--- a/src/sys/eventfd.rs
+++ b/src/sys/eventfd.rs
@@ -1,6 +1,6 @@
 use libc;
 use std::os::unix::io::RawFd;
-use {Error, Result};
+use errno::{Errno, Result};
 
 bitflags!(
     flags EventFdFlag: libc::c_int {
@@ -22,10 +22,6 @@ pub fn eventfd(initval: usize, flags: EventFdFlag) -> Result<RawFd> {
     unsafe {
         let res = ffi::eventfd(initval as libc::c_uint, flags.bits());
 
-        if res < 0 {
-            return Err(Error::last());
-        }
-
-        Ok(res as RawFd)
+        Errno::result(res).map(|r| r as RawFd)
     }
 }

--- a/src/sys/eventfd.rs
+++ b/src/sys/eventfd.rs
@@ -1,6 +1,6 @@
 use libc;
 use std::os::unix::io::RawFd;
-use errno::{Errno, Result};
+use {Errno, Result};
 
 bitflags!(
     flags EventFdFlag: libc::c_int {

--- a/src/sys/ioctl/platform/linux.rs
+++ b/src/sys/ioctl/platform/linux.rs
@@ -82,11 +82,7 @@ macro_rules! iorw {
 macro_rules! convert_ioctl_res {
     ($w:expr) => (
         {
-            let res = $w;
-            if res < 0 {
-                return Err($crate::Error::Sys($crate::errno::Errno::last()))
-            }
-            Ok(res) // res may contain useful information for user
+            $crate::Errno::result($w)
         }
     );
 }

--- a/src/sys/memfd.rs
+++ b/src/sys/memfd.rs
@@ -1,6 +1,6 @@
 use libc;
 use std::os::unix::io::RawFd;
-use {Error, Result};
+use errno::{Errno, Result};
 use std::ffi::CStr;
 
 bitflags!(
@@ -13,6 +13,6 @@ bitflags!(
 pub fn memfd_create(name: &CStr, flags: MemFdCreateFlag) -> Result<RawFd> {
     use sys::syscall::{syscall, MEMFD_CREATE};
     let res = unsafe { syscall(MEMFD_CREATE, name.as_ptr(), flags.bits()) };
-    if res == -1 { Err(Error::last()) }
-    else { Ok(res as RawFd) }
+
+    Errno::result(res).map(|r| r as RawFd)
 }

--- a/src/sys/memfd.rs
+++ b/src/sys/memfd.rs
@@ -1,6 +1,6 @@
 use libc;
 use std::os::unix::io::RawFd;
-use errno::{Errno, Result};
+use {Errno, Result};
 use std::ffi::CStr;
 
 bitflags!(

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -1,5 +1,5 @@
-use {Error, Result, NixPath};
-use errno::Errno;
+use {NixPath, Error};
+use errno::{Errno, Result};
 use fcntl::OFlag;
 use libc::{c_void, size_t, off_t, mode_t};
 use sys::stat::Mode;
@@ -191,17 +191,11 @@ mod ffi {
 }
 
 pub unsafe fn mlock(addr: *const c_void, length: size_t) -> Result<()> {
-    match ffi::mlock(addr, length) {
-        0 => Ok(()),
-        _ => Err(Error::Sys(Errno::last()))
-    }
+    Errno::result(ffi::mlock(addr, length)).map(drop)
 }
 
 pub fn munlock(addr: *const c_void, length: size_t) -> Result<()> {
-    match unsafe { ffi::munlock(addr, length) } {
-        0 => Ok(()),
-        _ => Err(Error::Sys(Errno::last()))
-    }
+    Errno::result(unsafe { ffi::munlock(addr, length) }).map(drop)
 }
 
 /// Calls to mmap are inherently unsafe, so they must be made in an unsafe block. Typically
@@ -217,24 +211,15 @@ pub fn mmap(addr: *mut c_void, length: size_t, prot: MmapProt, flags: MmapFlag, 
 }
 
 pub fn munmap(addr: *mut c_void, len: size_t) -> Result<()> {
-    match unsafe { ffi::munmap(addr, len) } {
-        0 => Ok(()),
-        _ => Err(Error::Sys(Errno::last()))
-    }
+    Errno::result(unsafe { ffi::munmap(addr, len) }).map(drop)
 }
 
 pub fn madvise(addr: *const c_void, length: size_t, advise: MmapAdvise) -> Result<()> {
-    match unsafe { ffi::madvise(addr, length, advise) } {
-        0 => Ok(()),
-        _ => Err(Error::Sys(Errno::last()))
-    }
+    Errno::result(unsafe { ffi::madvise(addr, length, advise) }).map(drop)
 }
 
 pub fn msync(addr: *const c_void, length: size_t, flags: MmapSync) -> Result<()> {
-    match unsafe { ffi::msync(addr, length, flags) } {
-        0 => Ok(()),
-        _ => Err(Error::Sys(Errno::last()))
-    }
+    Errno::result(unsafe { ffi::msync(addr, length, flags) }).map(drop)
 }
 
 pub fn shm_open<P: ?Sized + NixPath>(name: &P, flag: OFlag, mode: Mode) -> Result<RawFd> {
@@ -244,11 +229,7 @@ pub fn shm_open<P: ?Sized + NixPath>(name: &P, flag: OFlag, mode: Mode) -> Resul
         }
     }));
 
-    if ret < 0 {
-        Err(Error::Sys(Errno::last()))
-    } else {
-        Ok(ret)
-    }
+    Errno::result(ret)
 }
 
 pub fn shm_unlink<P: ?Sized + NixPath>(name: &P) -> Result<()> {
@@ -256,9 +237,5 @@ pub fn shm_unlink<P: ?Sized + NixPath>(name: &P) -> Result<()> {
         unsafe { ffi::shm_unlink(cstr.as_ptr()) }
     }));
 
-    if ret < 0 {
-        Err(Error::Sys(Errno::last()))
-    } else {
-        Ok(())
-    }
+    Errno::result(ret).map(drop)
 }

--- a/src/sys/mman.rs
+++ b/src/sys/mman.rs
@@ -1,5 +1,4 @@
-use {NixPath, Error};
-use errno::{Errno, Result};
+use {Errno, Error, Result, NixPath};
 use fcntl::OFlag;
 use libc::{c_void, size_t, off_t, mode_t};
 use sys::stat::Mode;

--- a/src/sys/ptrace.rs
+++ b/src/sys/ptrace.rs
@@ -1,5 +1,4 @@
-use Error;
-use errno::{Errno, Result};
+use {Errno, Error, Result};
 use libc::{pid_t, c_void, c_long};
 
 #[cfg(all(target_os = "linux",

--- a/src/sys/ptrace.rs
+++ b/src/sys/ptrace.rs
@@ -1,5 +1,5 @@
-use {Error, Result};
-use errno::Errno;
+use Error;
+use errno::{Errno, Result};
 use libc::{pid_t, c_void, c_long};
 
 #[cfg(all(target_os = "linux",
@@ -86,17 +86,14 @@ fn ptrace_peek(request: ptrace::PtraceRequest, pid: pid_t, addr: *mut c_void, da
         Errno::clear();
         ffi::ptrace(request, pid, addr, data)
     };
-    if ret == -1 && Errno::last() != Errno::UnknownErrno {
-        return Err(Error::Sys(Errno::last()));
+    match Errno::result(ret) {
+        Ok(..) | Err(Error::Sys(Errno::UnknownErrno)) => Ok(ret),
+        err @ Err(..) => err,
     }
-    Ok::<c_long, Error>(ret)
 }
 
 fn ptrace_other(request: ptrace::PtraceRequest, pid: pid_t, addr: *mut c_void, data: *mut c_void) -> Result<c_long> {
-    match unsafe { ffi::ptrace(request, pid, addr, data) } {
-        -1 => Err(Error::Sys(Errno::last())),
-        _  => Ok(0)
-    }
+    Errno::result(unsafe { ffi::ptrace(request, pid, addr, data) }).map(|_| 0)
 }
 
 /// Set options, as with ptrace(PTRACE_SETOPTIONS,...).
@@ -104,7 +101,5 @@ pub fn ptrace_setoptions(pid: pid_t, options: ptrace::PtraceOptions) -> Result<(
     use self::ptrace::*;
     use std::ptr;
 
-    try!(ptrace(PTRACE_SETOPTIONS, pid, ptr::null_mut(), options as *mut c_void));
-    Ok(())
+    ptrace(PTRACE_SETOPTIONS, pid, ptr::null_mut(), options as *mut c_void).map(drop)
 }
-

--- a/src/sys/quota.rs
+++ b/src/sys/quota.rs
@@ -1,5 +1,4 @@
-use NixPath;
-use errno::{Errno, Result};
+use {Errno, Result, NixPath};
 use libc::{c_int, c_char};
 
 #[cfg(all(target_os = "linux",

--- a/src/sys/quota.rs
+++ b/src/sys/quota.rs
@@ -1,5 +1,5 @@
-use {Result, NixPath, from_ffi};
-use errno::Errno;
+use NixPath;
+use errno::{Errno, Result};
 use libc::{c_int, c_char};
 
 #[cfg(all(target_os = "linux",
@@ -90,7 +90,8 @@ fn quotactl<P: ?Sized + NixPath>(cmd: quota::QuotaCmd, special: Option<&P>, id: 
                 None => Ok(ffi::quotactl(cmd.as_int(), ptr::null(), id, addr)),
             }
         );
-        from_ffi(res)
+
+        Errno::result(res).map(drop)
     }
 }
 

--- a/src/sys/select.rs
+++ b/src/sys/select.rs
@@ -1,8 +1,7 @@
 use std::ptr::null_mut;
 use std::os::unix::io::RawFd;
 use libc::c_int;
-use {Result, Error};
-use errno::Errno;
+use errno::{Errno, Result};
 use sys::time::TimeVal;
 
 pub const FD_SETSIZE: RawFd = 1024;
@@ -82,9 +81,5 @@ pub fn select(nfds: c_int,
         ffi::select(nfds, readfds, writefds, errorfds, timeout)
     };
 
-    if res == -1 {
-        Err(Error::Sys(Errno::last()))
-    } else {
-        Ok(res)
-    }
+    Errno::result(res)
 }

--- a/src/sys/select.rs
+++ b/src/sys/select.rs
@@ -1,7 +1,7 @@
 use std::ptr::null_mut;
 use std::os::unix::io::RawFd;
 use libc::c_int;
-use errno::{Errno, Result};
+use {Errno, Result};
 use sys::time::TimeVal;
 
 pub const FD_SETSIZE: RawFd = 1024;

--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -2,7 +2,7 @@
 // See http://rust-lang.org/COPYRIGHT.
 
 use libc;
-use errno::{Errno, Result};
+use {Errno, Result};
 use std::mem;
 use std::ptr;
 

--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -17,7 +17,7 @@
 //! signal handlers.
 use libc::{c_int, pid_t, uid_t};
 use unistd;
-use errno::{Errno, Result};
+use {Errno, Result};
 use sys::signal::signal::siginfo as signal_siginfo;
 pub use sys::signal::{self, SigSet};
 

--- a/src/sys/signalfd.rs
+++ b/src/sys/signalfd.rs
@@ -16,9 +16,8 @@
 //! Please note that signal discarding is not specific to `signalfd`, but also happens with regular
 //! signal handlers.
 use libc::{c_int, pid_t, uid_t};
-use {Error, Result};
 use unistd;
-use errno::Errno;
+use errno::{Errno, Result};
 use sys::signal::signal::siginfo as signal_siginfo;
 pub use sys::signal::{self, SigSet};
 
@@ -56,10 +55,7 @@ pub const CREATE_NEW_FD: RawFd = -1;
 /// See [the signalfd man page for more information](http://man7.org/linux/man-pages/man2/signalfd.2.html)
 pub fn signalfd(fd: RawFd, mask: &SigSet, flags: SfdFlags) -> Result<RawFd> {
     unsafe {
-        match ffi::signalfd(fd as c_int, mask.as_ref(), flags.bits()) {
-            -1 => Err(Error::Sys(Errno::last())),
-            res => Ok(res as RawFd),
-        }
+        Errno::result(ffi::signalfd(fd as c_int, mask.as_ref(), flags.bits()))
     }
 }
 

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -1,6 +1,6 @@
-use {Result, Error, NixPath};
 use super::{consts, sa_family_t};
-use errno::Errno;
+use {NixPath, Error};
+use errno::{Errno, Result};
 use libc;
 use std::{fmt, hash, mem, net, ptr};
 use std::ffi::OsStr;

--- a/src/sys/socket/addr.rs
+++ b/src/sys/socket/addr.rs
@@ -1,6 +1,5 @@
 use super::{consts, sa_family_t};
-use {NixPath, Error};
-use errno::{Errno, Result};
+use {Errno, Error, Result, NixPath};
 use libc;
 use std::{fmt, hash, mem, net, ptr};
 use std::ffi::OsStr;

--- a/src/sys/socket/mod.rs
+++ b/src/sys/socket/mod.rs
@@ -1,8 +1,7 @@
 //! Socket interface functions
 //!
 //! [Further reading](http://man7.org/linux/man-pages/man7/socket.7.html)
-use Error;
-use errno::{Errno, Result};
+use {Error, Errno, Result};
 use features;
 use fcntl::{fcntl, FD_CLOEXEC, O_NONBLOCK};
 use fcntl::FcntlArg::{F_SETFD, F_SETFL};

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -1,6 +1,5 @@
-use {Result, Error, from_ffi};
 use super::{ffi, consts, GetSockOpt, SetSockOpt};
-use errno::Errno;
+use errno::{Errno, Result};
 use sys::time::TimeVal;
 use libc::{c_int, uint8_t, c_void, socklen_t};
 use std::mem;
@@ -18,7 +17,7 @@ macro_rules! setsockopt_impl {
                     let res = ffi::setsockopt(fd, $level, $flag,
                                               setter.ffi_ptr(),
                                               setter.ffi_len());
-                    from_ffi(res)
+                    Errno::result(res).map(drop)
                 }
             }
         }
@@ -37,9 +36,7 @@ macro_rules! getsockopt_impl {
                     let res = ffi::getsockopt(fd, $level, $flag,
                                               getter.ffi_ptr(),
                                               getter.ffi_len());
-                    if res < 0 {
-                        return Err(Error::Sys(Errno::last()));
-                    }
+                    try!(Errno::result(res));
 
                     Ok(getter.unwrap())
                 }

--- a/src/sys/socket/sockopt.rs
+++ b/src/sys/socket/sockopt.rs
@@ -1,5 +1,5 @@
 use super::{ffi, consts, GetSockOpt, SetSockOpt};
-use errno::{Errno, Result};
+use {Errno, Result};
 use sys::time::TimeVal;
 use libc::{c_int, uint8_t, c_void, socklen_t};
 use std::mem;

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -1,8 +1,8 @@
 pub use libc::dev_t;
 pub use libc::stat as FileStat;
 
-use {Error, Result, NixPath, from_ffi};
-use errno::Errno;
+use NixPath;
+use errno::{Errno, Result};
 use libc::mode_t;
 use std::mem;
 use std::os::unix::io::RawFd;
@@ -56,7 +56,8 @@ pub fn mknod<P: ?Sized + NixPath>(path: &P, kind: SFlag, perm: Mode, dev: dev_t)
             ffi::mknod(cstr.as_ptr(), kind.bits | perm.bits() as mode_t, dev)
         }
     }));
-    from_ffi(res)
+
+    Errno::result(res).map(drop)
 }
 
 #[cfg(target_os = "linux")]
@@ -80,9 +81,7 @@ pub fn stat<P: ?Sized + NixPath>(path: &P) -> Result<FileStat> {
         }
     }));
 
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
+    try!(Errno::result(res));
 
     Ok(dst)
 }
@@ -95,9 +94,7 @@ pub fn lstat<P: ?Sized + NixPath>(path: &P) -> Result<FileStat> {
         }
     }));
 
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
+    try!(Errno::result(res));
 
     Ok(dst)
 }
@@ -106,9 +103,7 @@ pub fn fstat(fd: RawFd) -> Result<FileStat> {
     let mut dst = unsafe { mem::uninitialized() };
     let res = unsafe { ffi::fstat(fd, &mut dst as *mut FileStat) };
 
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
+    try!(Errno::result(res));
 
     Ok(dst)
 }

--- a/src/sys/stat.rs
+++ b/src/sys/stat.rs
@@ -1,8 +1,7 @@
 pub use libc::dev_t;
 pub use libc::stat as FileStat;
 
-use NixPath;
-use errno::{Errno, Result};
+use {Errno, Result, NixPath};
 use libc::mode_t;
 use std::mem;
 use std::os::unix::io::RawFd;

--- a/src/sys/statfs.rs
+++ b/src/sys/statfs.rs
@@ -1,5 +1,5 @@
-use {Result, NixPath, from_ffi};
-use errno::Errno;
+use NixPath;
+use errno::{Errno, Result};
 use std::os::unix::io::AsRawFd;
 
 pub mod vfs {
@@ -104,13 +104,14 @@ pub fn statfs<P: ?Sized + NixPath>(path: &P, stat: &mut vfs::Statfs) -> Result<(
         let res = try!(
             path.with_nix_path(|path| ffi::statfs(path.as_ptr(), stat))
         );
-        from_ffi(res)
+
+        Errno::result(res).map(drop)
     }
 }
 
 pub fn fstatfs<T: AsRawFd>(fd: &T, stat: &mut vfs::Statfs) -> Result<()> {
     unsafe {
         Errno::clear();
-        from_ffi(ffi::fstatfs(fd.as_raw_fd(), stat))
+        Errno::result(ffi::fstatfs(fd.as_raw_fd(), stat)).map(drop)
     }
 }

--- a/src/sys/statfs.rs
+++ b/src/sys/statfs.rs
@@ -1,5 +1,4 @@
-use NixPath;
-use errno::{Errno, Result};
+use {Errno, Result, NixPath};
 use std::os::unix::io::AsRawFd;
 
 pub mod vfs {

--- a/src/sys/statvfs.rs
+++ b/src/sys/statvfs.rs
@@ -2,8 +2,8 @@
 //!
 //! See the `vfs::Statvfs` struct for some rusty wrappers
 
-use {Result, NixPath, from_ffi};
-use errno::Errno;
+use NixPath;
+use errno::{Errno, Result};
 use std::os::unix::io::AsRawFd;
 
 pub mod vfs {
@@ -147,7 +147,8 @@ pub fn statvfs<P: ?Sized + NixPath>(path: &P, stat: &mut vfs::Statvfs) -> Result
         let res = try!(
             path.with_nix_path(|path| ffi::statvfs(path.as_ptr(), stat))
         );
-        from_ffi(res)
+
+        Errno::result(res).map(drop)
     }
 }
 
@@ -155,7 +156,7 @@ pub fn statvfs<P: ?Sized + NixPath>(path: &P, stat: &mut vfs::Statvfs) -> Result
 pub fn fstatvfs<T: AsRawFd>(fd: &T, stat: &mut vfs::Statvfs) -> Result<()> {
     unsafe {
         Errno::clear();
-        from_ffi(ffi::fstatvfs(fd.as_raw_fd(), stat))
+        Errno::result(ffi::fstatvfs(fd.as_raw_fd(), stat)).map(drop)
     }
 }
 

--- a/src/sys/statvfs.rs
+++ b/src/sys/statvfs.rs
@@ -2,8 +2,7 @@
 //!
 //! See the `vfs::Statvfs` struct for some rusty wrappers
 
-use NixPath;
-use errno::{Errno, Result};
+use {Errno, Result, NixPath};
 use std::os::unix::io::AsRawFd;
 
 pub mod vfs {

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -1,5 +1,4 @@
-use {Error, Result, from_ffi};
-use errno::Errno;
+use errno::{Errno, Result};
 use libc::c_int;
 use std::mem;
 use std::os::unix::io::RawFd;
@@ -440,15 +439,15 @@ pub fn cfgetospeed(termios: &Termios) -> speed_t {
 }
 
 pub fn cfsetispeed(termios: &mut Termios, speed: speed_t) -> Result<()> {
-    from_ffi(unsafe {
+    Errno::result(unsafe {
         ffi::cfsetispeed(termios, speed)
-    })
+    }).map(drop)
 }
 
 pub fn cfsetospeed(termios: &mut Termios, speed: speed_t) -> Result<()> {
-    from_ffi(unsafe {
+    Errno::result(unsafe {
         ffi::cfsetospeed(termios, speed)
-    })
+    }).map(drop)
 }
 
 pub fn tcgetattr(fd: RawFd) -> Result<Termios> {
@@ -458,9 +457,7 @@ pub fn tcgetattr(fd: RawFd) -> Result<Termios> {
         ffi::tcgetattr(fd, &mut termios)
     };
 
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
+    try!(Errno::result(res));
 
     Ok(termios)
 }
@@ -468,31 +465,31 @@ pub fn tcgetattr(fd: RawFd) -> Result<Termios> {
 pub fn tcsetattr(fd: RawFd,
                  actions: SetArg,
                  termios: &Termios) -> Result<()> {
-    from_ffi(unsafe {
+    Errno::result(unsafe {
         ffi::tcsetattr(fd, actions as c_int, termios)
-    })
+    }).map(drop)
 }
 
 pub fn tcdrain(fd: RawFd) -> Result<()> {
-    from_ffi(unsafe {
+    Errno::result(unsafe {
         ffi::tcdrain(fd)
-    })
+    }).map(drop)
 }
 
 pub fn tcflow(fd: RawFd, action: FlowArg) -> Result<()> {
-    from_ffi(unsafe {
+    Errno::result(unsafe {
         ffi::tcflow(fd, action as c_int)
-    })
+    }).map(drop)
 }
 
 pub fn tcflush(fd: RawFd, action: FlushArg) -> Result<()> {
-    from_ffi(unsafe {
+    Errno::result(unsafe {
         ffi::tcflush(fd, action as c_int)
-    })
+    }).map(drop)
 }
 
 pub fn tcsendbreak(fd: RawFd, action: c_int) -> Result<()> {
-    from_ffi(unsafe {
+    Errno::result(unsafe {
         ffi::tcsendbreak(fd, action)
-    })
+    }).map(drop)
 }

--- a/src/sys/termios.rs
+++ b/src/sys/termios.rs
@@ -1,4 +1,4 @@
-use errno::{Errno, Result};
+use {Errno, Result};
 use libc::c_int;
 use std::mem;
 use std::os::unix::io::RawFd;

--- a/src/sys/uio.rs
+++ b/src/sys/uio.rs
@@ -1,8 +1,7 @@
 // Silence invalid warnings due to rust-lang/rust#16719
 #![allow(improper_ctypes)]
 
-use {Result, Error};
-use errno::Errno;
+use errno::{Errno, Result};
 use libc::{c_int, c_void, size_t, off_t};
 use std::marker::PhantomData;
 use std::os::unix::io::RawFd;
@@ -48,20 +47,13 @@ mod ffi {
 pub fn writev(fd: RawFd, iov: &[IoVec<&[u8]>]) -> Result<usize> {
     let res = unsafe { ffi::writev(fd, iov.as_ptr(), iov.len() as c_int) };
 
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-
-    return Ok(res as usize)
+    Errno::result(res).map(|r| r as usize)
 }
 
 pub fn readv(fd: RawFd, iov: &mut [IoVec<&mut [u8]>]) -> Result<usize> {
     let res = unsafe { ffi::readv(fd, iov.as_ptr(), iov.len() as c_int) };
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
 
-    return Ok(res as usize)
+    Errno::result(res).map(|r| r as usize)
 }
 
 #[cfg(feature = "preadv_pwritev")]
@@ -70,11 +62,8 @@ pub fn pwritev(fd: RawFd, iov: &[IoVec<&[u8]>],
     let res = unsafe {
         ffi::pwritev(fd, iov.as_ptr(), iov.len() as c_int, offset)
     };
-    if res < 0 {
-        Err(Error::Sys(Errno::last()))
-    } else {
-        Ok(res as usize)
-    }
+
+    Errno::result(res).map(|r| r as usize)
 }
 
 #[cfg(feature = "preadv_pwritev")]
@@ -83,11 +72,8 @@ pub fn preadv(fd: RawFd, iov: &mut [IoVec<&mut [u8]>],
     let res = unsafe {
         ffi::preadv(fd, iov.as_ptr(), iov.len() as c_int, offset)
     };
-    if res < 0 {
-        Err(Error::Sys(Errno::last()))
-    } else {
-        Ok(res as usize)
-    }
+
+    Errno::result(res).map(|r| r as usize)
 }
 
 pub fn pwrite(fd: RawFd, buf: &[u8], offset: off_t) -> Result<usize> {
@@ -95,11 +81,8 @@ pub fn pwrite(fd: RawFd, buf: &[u8], offset: off_t) -> Result<usize> {
         ffi::pwrite(fd, buf.as_ptr() as *const c_void, buf.len() as size_t,
                     offset)
     };
-    if res < 0 {
-        Err(Error::Sys(Errno::last()))
-    } else {
-        Ok(res as usize)
-    }
+
+    Errno::result(res).map(|r| r as usize)
 }
 
 pub fn pread(fd: RawFd, buf: &mut [u8], offset: off_t) -> Result<usize>{
@@ -107,11 +90,8 @@ pub fn pread(fd: RawFd, buf: &mut [u8], offset: off_t) -> Result<usize>{
         ffi::pread(fd, buf.as_mut_ptr() as *mut c_void, buf.len() as size_t,
                    offset)
     };
-    if res < 0 {
-        Err(Error::Sys(Errno::last()))
-    } else {
-        Ok(res as usize)
-    }
+
+    Errno::result(res).map(|r| r as usize)
 }
 
 #[repr(C)]

--- a/src/sys/uio.rs
+++ b/src/sys/uio.rs
@@ -1,7 +1,7 @@
 // Silence invalid warnings due to rust-lang/rust#16719
 #![allow(improper_ctypes)]
 
-use errno::{Errno, Result};
+use {Errno, Result};
 use libc::{c_int, c_void, size_t, off_t};
 use std::marker::PhantomData;
 use std::os::unix::io::RawFd;

--- a/src/sys/wait.rs
+++ b/src/sys/wait.rs
@@ -1,5 +1,5 @@
 use libc::{pid_t, c_int};
-use errno::{Errno, Result};
+use {Errno, Result};
 
 use sys::signal;
 

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1,7 +1,7 @@
 //! Standard symbolic constants and types
 //!
-use {Error, Result, NixPath, from_ffi};
-use errno::Errno;
+use {NixPath, Error};
+use errno::{Errno, Result};
 use fcntl::{fcntl, OFlag, O_NONBLOCK, O_CLOEXEC, FD_CLOEXEC};
 use fcntl::FcntlArg::{F_SETFD, F_SETFL};
 use libc::{c_char, c_void, c_int, size_t, pid_t, off_t, uid_t, gid_t};
@@ -91,17 +91,12 @@ impl Fork {
 }
 
 pub fn fork() -> Result<Fork> {
-    use self::Fork::*;
-
     let res = unsafe { ffi::fork() };
 
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    } else if res == 0 {
-        Ok(Child)
-    } else {
-        Ok(Parent(res))
-    }
+    Errno::result(res).map(|res| match res {
+        0 => Fork::Child,
+        res => Fork::Parent(res)
+    })
 }
 
 #[inline]
@@ -115,32 +110,21 @@ pub fn getppid() -> pid_t {
 #[inline]
 pub fn setpgid(pid: pid_t, pgid: pid_t) -> Result<()> {
     let res = unsafe { ffi::setpgid(pid, pgid) };
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-    Ok(())
+    Errno::result(res).map(drop)
 }
 
 #[inline]
 pub fn dup(oldfd: RawFd) -> Result<RawFd> {
     let res = unsafe { ffi::dup(oldfd) };
 
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-
-    Ok(res)
+    Errno::result(res)
 }
 
 #[inline]
 pub fn dup2(oldfd: RawFd, newfd: RawFd) -> Result<RawFd> {
     let res = unsafe { ffi::dup2(oldfd, newfd) };
 
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-
-    Ok(res)
+    Errno::result(res)
 }
 
 pub fn dup3(oldfd: RawFd, newfd: RawFd, flags: OFlag) -> Result<RawFd> {
@@ -171,11 +155,7 @@ pub fn chdir<P: ?Sized + NixPath>(path: &P) -> Result<()> {
         unsafe { ffi::chdir(cstr.as_ptr()) }
     }));
 
-    if res != 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-
-    return Ok(())
+    Errno::result(res).map(drop)
 }
 
 fn to_exec_array(args: &[CString]) -> Vec<*const c_char> {
@@ -223,7 +203,7 @@ pub fn execvp(filename: &CString, args: &[CString]) -> Result<()> {
 
 pub fn daemon(nochdir: bool, noclose: bool) -> Result<()> {
     let res = unsafe { ffi::daemon(nochdir as c_int, noclose as c_int) };
-    from_ffi(res)
+    Errno::result(res).map(drop)
 }
 
 pub fn sethostname(name: &[u8]) -> Result<()> {
@@ -231,7 +211,7 @@ pub fn sethostname(name: &[u8]) -> Result<()> {
     let len = name.len() as size_t;
 
     let res = unsafe { ffi::sethostname(ptr, len) };
-    from_ffi(res)
+    Errno::result(res).map(drop)
 }
 
 pub fn gethostname(name: &mut [u8]) -> Result<()> {
@@ -239,32 +219,24 @@ pub fn gethostname(name: &mut [u8]) -> Result<()> {
     let len = name.len() as size_t;
 
     let res = unsafe { ffi::gethostname(ptr, len) };
-    from_ffi(res)
+    Errno::result(res).map(drop)
 }
 
 pub fn close(fd: RawFd) -> Result<()> {
     let res = unsafe { ffi::close(fd) };
-    from_ffi(res)
+    Errno::result(res).map(drop)
 }
 
 pub fn read(fd: RawFd, buf: &mut [u8]) -> Result<usize> {
     let res = unsafe { ffi::read(fd, buf.as_mut_ptr() as *mut c_void, buf.len() as size_t) };
 
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-
-    return Ok(res as usize)
+    Errno::result(res).map(|r| r as usize)
 }
 
 pub fn write(fd: RawFd, buf: &[u8]) -> Result<usize> {
     let res = unsafe { ffi::write(fd, buf.as_ptr() as *const c_void, buf.len() as size_t) };
 
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-
-    return Ok(res as usize)
+    Errno::result(res).map(|r| r as usize)
 }
 
 pub fn pipe() -> Result<(RawFd, RawFd)> {
@@ -273,9 +245,7 @@ pub fn pipe() -> Result<(RawFd, RawFd)> {
 
         let res = ffi::pipe(fds.as_mut_ptr());
 
-        if res < 0 {
-            return Err(Error::Sys(Errno::last()));
-        }
+        try!(Errno::result(res));
 
         Ok((fds[0], fds[1]))
     }
@@ -287,9 +257,7 @@ pub fn pipe2(flags: OFlag) -> Result<(RawFd, RawFd)> {
 
         let res = ffi::pipe(fds.as_mut_ptr());
 
-        if res < 0 {
-            return Err(Error::Sys(Errno::last()));
-        }
+        try!(Errno::result(res));
 
         try!(pipe2_setflags(fds[0], fds[1], flags));
 
@@ -323,35 +291,34 @@ fn pipe2_setflags(fd1: RawFd, fd2: RawFd, flags: OFlag) -> Result<()> {
 }
 
 pub fn ftruncate(fd: RawFd, len: off_t) -> Result<()> {
-    if unsafe { ffi::ftruncate(fd, len) } < 0 {
-        Err(Error::Sys(Errno::last()))
-    } else {
-        Ok(())
-    }
+    Errno::result(unsafe { ffi::ftruncate(fd, len) }).map(drop)
 }
 
 pub fn isatty(fd: RawFd) -> Result<bool> {
     use libc;
 
-    if unsafe { libc::isatty(fd) } == 1 {
-        Ok(true)
-    } else {
-        match Errno::last() {
-            // ENOTTY means `fd` is a valid file descriptor, but not a TTY, so
-            // we return `Ok(false)`
-            Errno::ENOTTY => Ok(false),
-            err => Err(Error::Sys(err))
+    unsafe {
+        // ENOTTY means `fd` is a valid file descriptor, but not a TTY, so
+        // we return `Ok(false)`
+        if libc::isatty(fd) == 1 {
+            Ok(true)
+        } else {
+            match Errno::last() {
+                Errno::ENOTTY => Ok(false),
+                err => Err(Error::Sys(err)),
+            }
         }
     }
 }
 
 pub fn unlink<P: ?Sized + NixPath>(path: &P) -> Result<()> {
     let res = try!(path.with_nix_path(|cstr| {
-    unsafe {
-        ffi::unlink(cstr.as_ptr())
-    }
+        unsafe {
+            ffi::unlink(cstr.as_ptr())
+        }
     }));
-    from_ffi(res)
+
+    Errno::result(res).map(drop)
 }
 
 #[inline]
@@ -360,33 +327,21 @@ pub fn chroot<P: ?Sized + NixPath>(path: &P) -> Result<()> {
         unsafe { ffi::chroot(cstr.as_ptr()) }
     }));
 
-    if res != 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-
-    Ok(())
+    Errno::result(res).map(drop)
 }
 
 #[inline]
 pub fn fsync(fd: RawFd) -> Result<()> {
     let res = unsafe { ffi::fsync(fd) };
 
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-
-    Ok(())
+    Errno::result(res).map(drop)
 }
 
 #[inline]
 pub fn fdatasync(fd: RawFd) -> Result<()> {
     let res = unsafe { ffi::fdatasync(fd) };
 
-    if res < 0 {
-        return Err(Error::Sys(Errno::last()));
-    }
-
-    Ok(())
+    Errno::result(res).map(drop)
 }
 
 // POSIX requires that getuid, geteuid, getgid, getegid are always successful,
@@ -418,8 +373,8 @@ pub fn getegid() -> gid_t {
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod linux {
     use sys::syscall::{syscall, SYSPIVOTROOT};
-    use errno::Errno;
-    use {Error, Result, NixPath};
+    use NixPath;
+    use errno::{Errno, Result};
 
     #[cfg(feature = "execvpe")]
     use std::ffi::CString;
@@ -434,11 +389,7 @@ mod linux {
             })
         })));
 
-        if res != 0 {
-            return Err(Error::Sys(Errno::last()));
-        }
-
-        Ok(())
+        Errno::result(res).map(drop)
     }
 
     #[inline]

--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -1,7 +1,6 @@
 //! Standard symbolic constants and types
 //!
-use {NixPath, Error};
-use errno::{Errno, Result};
+use {Errno, Error, Result, NixPath};
 use fcntl::{fcntl, OFlag, O_NONBLOCK, O_CLOEXEC, FD_CLOEXEC};
 use fcntl::FcntlArg::{F_SETFD, F_SETFL};
 use libc::{c_char, c_void, c_int, size_t, pid_t, off_t, uid_t, gid_t};
@@ -373,8 +372,7 @@ pub fn getegid() -> gid_t {
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod linux {
     use sys::syscall::{syscall, SYSPIVOTROOT};
-    use NixPath;
-    use errno::{Errno, Result};
+    use {Errno, Result, NixPath};
 
     #[cfg(feature = "execvpe")]
     use std::ffi::CString;


### PR DESCRIPTION
A replacement of `from_ffi`, and updates all methods to use it. Partial preparation for #230 where `Error` will be replaced by `Errno`.

Changes are on top of #246, so merge that first!