### PR TITLE
signal: Allow raw_pointer_derive on SigAction struct

### DIFF
--- a/src/sys/signal.rs
+++ b/src/sys/signal.rs
@@ -380,6 +380,7 @@ impl AsRef<sigset_t> for SigSet {
 
 pub use self::signal::siginfo;
 
+#[allow(raw_pointer_derive)]
 #[derive(Clone, Copy)]
 pub enum SigHandler {
     SigDfl,


### PR DESCRIPTION
This will fix the build on pre-1.6.0 Rust.